### PR TITLE
fix: Update NODE_VERSION to 20 in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -24,6 +24,6 @@ services:
         destination: /index.html
     envVars:
       - key: NODE_VERSION
-        value: 18.20.0
+        value: 20
       - key: NODE_ENV
         value: production


### PR DESCRIPTION
## Issue

Render deploy failing because Docusaurus 3.9.2 requires Node.js >=20.0 but `render.yaml` was setting `NODE_VERSION=18.20.0`.

## Fix

Update `NODE_VERSION` from `18.20.0` to `20` in render.yaml blueprint.

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)