### PR TITLE
fix: Update broken link to archived MCP doc

### DIFF
--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -36,4 +36,4 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 - Use `/compact` to shrink long conversations, or switch to a larger‑context model via `/model` when needed.
 - Run `/init` to generate AGENTS.md so that AdaL can understand your codebase better.
 
-**Related:** [MCP Support](./mcp-support.md) · [Troubleshooting](../07-troubleshooting/installation.md)
+**Related:** [MCP](./mcp-support-proposed.md) · [Troubleshooting](../07-troubleshooting/installation.md)


### PR DESCRIPTION
## Issue

Render deploy failed due to broken link in `slash-commands.md` pointing to `mcp-support.md` (archived).

## Fix

Updated link to point to `mcp-support-proposed.md` (the new MCP documentation).

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)