### PR TITLE
fix: Remove non-functional search plugin

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -48,16 +48,6 @@ const config: Config = {
     ],
   ],
 
-  themes: [
-    [
-      '@easyops-cn/docusaurus-search-local',
-      {
-        hashed: true,
-        language: ['en'],
-        highlightSearchTermsOnTargetPage: true,
-      },
-    ],
-  ],
 
   themeConfig: {
     // Replace with your project's social card

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@docusaurus/core": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",
-    "@easyops-cn/docusaurus-search-local": "^0.52.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^2.1.0",


### PR DESCRIPTION
## Issue

The local search plugin only works after build, not in dev mode.

## Fix

Removed @easyops-cn/docusaurus-search-local plugin entirely.

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)