### PR TITLE
Fix broken link in models.md

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -94,4 +94,4 @@ See [Pricing](https://app.adal.ml/subscription) for subscription tiers and credi
 
 ---
 
-**Related:** [Quickstart](./your-first-session.md) · [Input Methods](./input-methods.md) · [BYOAK](../features/bring-your-own-api-key.md)
+**Related:** [Quickstart](./your-first-session.md) · [Input Methods](./input-methods.md) · [BYOAK](../03-features/bring-your-own-api-key.md)


### PR DESCRIPTION
## Summary

Fixes broken link in models.md that was causing Docusaurus build failures.

## Changes

- Fixed link path from `../features/bring-your-own-api-key.md` to `../03-features/bring-your-own-api-key.md`

🌸 Generated with [AdaL](https://github.com/adal-cli/)