### PR TITLE
Docs/resume and mcp changes

### DIFF
--- a/docs-site/docs/03-features/manage-conversations.md
+++ b/docs-site/docs/03-features/manage-conversations.md
@@ -70,7 +70,7 @@ Your terminal shows the last 10 messages to stay fast. To see everything, copy t
 **Benefits:**
 - **Complete history** - See every message, tool call, and response
 - **Syntax highlighting** - Code blocks with proper formatting
-- **Searchable** - Find commands instantly with Cmd+F
+- **Searchable** - Find commands instantly with Cmd+F (macOS) or Ctrl+F (Windows/Linux)
 - **Shareable** - Save or share the HTML file
 
 Perfect for reviewing long sessions or documenting your workflow.

--- a/docs-site/docs/03-features/mcp-support-proposed.md
+++ b/docs-site/docs/03-features/mcp-support-proposed.md
@@ -61,7 +61,10 @@ Pre-configured by the AdaL CLI team. Just use the name - no flags needed.
 **API Key Servers** (github, gitlab, slack):
 ```bash
 # Set token BEFORE starting AdaL
-export GITHUB_TOKEN="ghp_xxxx"
+export GITHUB_TOKEN="ghp_xxxx" # macOS / Linux 
+# OR
+$env:GITHUB_TOKEN="ghp_xxxx" # Windows
+
 adal
 /mcp add github
 ```


### PR DESCRIPTION
### **Changes**
**MCP Authentication** ([SYL-187](https://linear.app/sylph-ai/issue/SYL-187/mcp-documentation-for-github))
   - Added Windows PowerShell syntax for setting environment variables
   - Previously only showed macOS/Linux export command
   - Now includes both: `export GITHUB_TOKEN=""` (macOS/Linux) and `$env:GITHUB_TOKEN=""` (Windows PowerShell)

 
**Resume Feature Search Shortcut** ([SYL-188](https://linear.app/sylph-ai/issue/SYL-188/resume-documentation))
   - Added platform-specific search shortcuts for the searchable resume feature
   - macOS: `Cmd+F`
   - Windows/Linux: `Ctrl+F`

