### PR TITLE
docs: add plugins-and-skills guide and update workflows examples

### DIFF
--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -9,6 +9,34 @@ Practical patterns for everyday development.
 
 ---
 
+## Terminal Setup
+
+**Recommended terminals:**
+- **Native terminal** — macOS Terminal, iTerm2, Windows Terminal, or your Linux terminal
+- **VS Code integrated terminal** — Drag the terminal panel to the top-right corner for a wider, taller view
+
+**Tip:** A larger terminal window gives AdaL more room to display code and diffs clearly.
+
+---
+
+## Set Up Project Context
+
+Ensure AdaL understands your codebase by creating an `AGENTS.md` file:
+
+```
+/init
+```
+
+This generates a project-specific `AGENTS.md` with:
+- Repository structure and key files
+- Build commands and workflows
+- Coding conventions and patterns
+- Important context for better assistance
+
+**Tip:** Review and customize the generated file for your team's needs.
+
+---
+
 ## Explore Codebase
 
 ```
@@ -132,13 +160,22 @@ Analyze thoroughly the performance bottlenecks
 
 ---
 
-## Session Management
+## Manage Work Sessions
+
+Keep your session focused and clean:
 
 ```
-/compact    # Reduce context
+/clear      # Clear context and start fresh
+/compact    # Summarize and reduce context (keep working)
 /resume     # Resume previous session
 /quit       # Exit (or Ctrl+C)
 ```
+
+**Auto-compact:** AdaL automatically compacts when context grows large, preserving key information while freeing space.
+
+**When to use:**
+- `/clear` — Switching to unrelated task
+- `/compact` — Long session getting slow, want to continue same work
 
 ---
 

--- a/docs-site/docs/03-features/plugins-and-skills.md
+++ b/docs-site/docs/03-features/plugins-and-skills.md
@@ -1,0 +1,235 @@
+---
+sidebar_position: 3.5
+title: Skills
+---
+
+# Skills
+
+**Skills** are reusable, filesystem-based resources that provide the agent with domain-specific expertise: workflows, context, and best practices that transform general-purpose agents into specialists.
+
+:::tip Compatibility
+AdaL skills are compatible with [Claude Code skills](https://code.claude.com/docs/en/skills). You can use any Claude Code skill repository with AdaL.
+:::
+
+## What Are Skills?
+
+Think of Skills as a hybrid of **MCP** and **AGENTS.md**:
+- Unlike AGENTS.md (which loads all project context upfront), Skills load **on-demand** when relevant
+- Unlike MCP servers (which require running processes), Skills are **simple markdown files** with optional bash scripts for tools
+
+This means you don't need to repeatedly provide the same guidance across conversations—the agent discovers and loads the right expertise automatically.
+
+**Key characteristics:**
+- **Filesystem-based**: Skills live in folders containing `SKILL.md` and optional supporting files
+- **On-demand loading**: Agent searches and loads skills when your task matches
+- **Tool integration**: Skills can include bash scripts that the agent executes as tools
+
+### Skill Sources
+
+Skills come from three places:
+
+| Source | Location | Use Case |
+|--------|----------|----------|
+| **Personal** | `~/.adal/skills/` | Your custom skills |
+| **Project** | `.adal/skills/` | Team skills shared via git |
+| **Plugin** | `~/.adal/plugin-cache/` | External skills from GitHub |
+
+### Understanding the Hierarchy
+
+For external skills, there's a three-level structure:
+
+```
+Marketplace (GitHub repo, e.g., anthropics/skills)
+    └── Plugin (skill group, e.g., document-skills)
+            └── Skill (individual capability, e.g., xlsx, docx, pdf)
+```
+
+- **Marketplace**: A GitHub repository containing one or more plugins. Add with `/plugin marketplace add`.
+- **Plugin**: A group of related skills. Install with `/plugin install` or via the `/plugin` dialog.
+- **Skill**: An individual capability. Used automatically by the agent.
+
+**Example:** The [anthropics/skills](https://github.com/anthropics/skills) marketplace contains the `document-skills` plugin, which includes skills for `xlsx`, `docx`, `pptx`, and `pdf`.
+
+## Quick Start & Commands
+
+| Step | Command | Description |
+|------|---------|-------------|
+| 1 | `/plugin marketplace add <owner/repo>` | **Add a marketplace** (one-time setup) |
+| 2 | `/plugin` | Browse available plugins and marketplaces |
+| 3 | `/plugin install <plugin>@<marketplace>` | Install a plugin (or use dialog) |
+| 4 | `/skills` | Browse all installed skills |
+| 5 | *Use naturally* | The agent invokes skills when relevant |
+
+**Example workflow:**
+```bash
+/plugin marketplace add anthropics/skills    # Add marketplace
+/plugin                                       # Browse & install via dialog
+/skills                                       # See installed skills
+> Create a PowerPoint presentation           # Agent uses pptx skill automatically
+```
+
+**Other commands:**
+| Command | Description |
+|---------|-------------|
+| `/plugin marketplace remove <name>` | Remove a marketplace |
+| `/plugin uninstall <plugin>@<marketplace>` | Uninstall a plugin |
+
+> **Note:** The `<marketplace>` in install/uninstall refers to the marketplace **name** (from `marketplace.json`), not the GitHub repo. For example, `anthropics/skills` repo → marketplace name `anthropic-agent-skills`.
+
+## Interactive Dialogs
+
+### Skills Browser (`/skills`)
+
+View all installed skills grouped by source:
+
+```
+> Skills (Page 1/2)
+
+Personal (~/.adal/skills/):
+  my-custom-skill
+
+Project (.adal/skills/):
+→ team-workflow
+
+Plugins:
+  xlsx (document-skills@anthropic-agent-skills)
+  docx (document-skills@anthropic-agent-skills)
+  pptx (document-skills@anthropic-agent-skills)
+  pdf (document-skills@anthropic-agent-skills)
+```
+
+### Plugin Browser (`/plugin`)
+
+Navigate with arrow keys, press Enter to view details or install:
+
+```
+> Plugins
+
+anthropic-agent-skills:
+→ ✓ document-skills (installed)
+  ○ example-skills
+
+huggingface-skills:
+  ○ model-trainer
+  ○ dataset-creator
+
+Tips:
+  /plugin install <name>@<repo> to install
+  /plugin marketplace add <owner/repo> to add repository
+```
+
+## Example Skill Repositories
+
+### Anthropic Official Skills
+
+**Repository:** [github.com/anthropics/skills](https://github.com/anthropics/skills)
+
+```bash
+/plugin marketplace add anthropics/skills
+```
+
+**Collections:**
+- `document-skills` - Excel, Word, PowerPoint, PDF processing
+- `example-skills` - Algorithmic art, frontend design, MCP builder
+
+### Hugging Face Skills
+
+**Repository:** [github.com/huggingface/skills](https://github.com/huggingface/skills)
+
+```bash
+/plugin marketplace add huggingface/skills
+```
+
+**Collections:**
+- `model-trainer` - Train/fine-tune LLMs using TRL on HF Jobs
+- `hugging-face-paper-publisher` - Publish research papers
+- `hugging-face-dataset-creator` - Create and manage datasets
+
+### Community Resources
+
+- **[Awesome Claude Skills](https://github.com/travisvn/awesome-claude-skills)** - Curated community skills
+- **[Skills Marketplace](https://skillsmp.com/)** - 25k+ community skills
+
+## Creating Your Own Skills
+
+### Personal Skills (`~/.adal/skills/`)
+
+Create a folder with a `SKILL.md` file:
+
+```bash
+mkdir -p ~/.adal/skills/my-skill
+```
+
+**~/.adal/skills/my-skill/SKILL.md:**
+```yaml
+---
+name: my-skill
+description: Brief description of what this skill does and when to use it
+---
+
+# My Skill
+
+## When to Use
+Describe when the agent should use this skill.
+
+## Instructions
+Provide step-by-step instructions for the agent to follow.
+```
+
+### Advanced: Multi-file Skill Structure
+
+Skills can bundle additional resources that the agent loads as needed. The agent discovers supporting files through links in your `SKILL.md`.
+
+**Content types:**
+- **Instructions** - Additional markdown files (FORMS.md, REFERENCE.md) with specialized guidance and workflows
+- **Code** - Executable scripts (fill_form.py, validate.py) that the agent runs via bash; scripts provide deterministic operations without consuming context
+- **Resources** - Reference materials like database schemas, API documentation, templates, or examples
+
+The agent accesses these files only when referenced. Each content type has different strengths: **instructions** for flexible guidance, **code** for reliability, **resources** for factual lookup.
+
+**Example: pdf-skill**
+```
+pdf-skill/
+├── SKILL.md        # Main instructions (required)
+├── FORMS.md        # Form-filling guide
+├── REFERENCE.md    # Detailed API reference
+└── scripts/
+    └── fill_form.py    # Utility script
+```
+
+In your `SKILL.md`, link to supporting files:
+```markdown
+For form filling, see [FORMS.md](./FORMS.md).
+For API details, see [REFERENCE.md](./REFERENCE.md).
+To fill a form: `python scripts/fill_form.py`
+```
+
+The agent reads linked files when relevant and executes scripts via bash.
+
+### Project Skills (`.adal/skills/`)
+
+Same format, but in your project directory. These are shared with your team via git.
+
+```bash
+mkdir -p .adal/skills/team-workflow
+```
+
+## Skill Priority
+
+When skills have the same name, first-loaded wins:
+1. **Personal** (`~/.adal/skills/`) - highest priority
+2. **Project** (`.adal/skills/`)
+3. **Plugin** (`~/.adal/plugin-cache/`) - lowest priority
+
+## Storage Locations
+
+| Path | Purpose |
+|------|---------|
+| `~/.adal/plugin-cache/` | Cloned marketplace repos |
+| `~/.adal/skills/` | Personal skills |
+| `.adal/skills/` | Project-specific skills |
+| `~/.adal/settings.json` | Plugin settings |
+
+---
+
+**Related:** [Slash Commands](./slash-commands.md) · [MCP Support](./mcp-support-proposed.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the plugins and skills system and updates the workflows examples.

## Changes

- **New**: `docs-site/docs/03-features/plugins-and-skills.md` - Comprehensive guide covering:
  - Skill system overview
  - How to use skills
  - Plugin management

- **Updated**: `docs-site/docs/01-getting-started/workflows-and-examples.md` - Improved content and examples

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)