### PR TITLE
docs: add Windows PowerShell instructions and fix keyboard shortcuts

### DIFF
--- a/docs-site/archive/mcp-support.md
+++ b/docs-site/archive/mcp-support.md
@@ -113,7 +113,8 @@ Done! Now AdaL can use the server's tools.
 **API Key Services** (set environment variable first):
 ```bash
 # Set your token
-export GITHUB_TOKEN="ghp_xxxxxxxxxxxx"
+export GITHUB_TOKEN="ghp_xxxxxxxxxxxx"  # macOS / Linux
+$env:GITHUB_TOKEN="ghp_xxxxxxxxxxxx"    # Windows PowerShell
 
 # Add server
 /mcp add github      # Repositories and issues
@@ -211,10 +212,12 @@ Examples:
 # Slack: https://api.slack.com/apps
 
 # 2. Set your token (AdaL must be closed)
-export GITHUB_TOKEN="your_token_here"
+export GITHUB_TOKEN="your_token_here"       # macOS / Linux
+$env:GITHUB_TOKEN="your_token_here"         # Windows PowerShell
 
 # 3. Verify the token is set (should display your token)
-echo $GITHUB_TOKEN
+echo $GITHUB_TOKEN                          # macOS / Linux
+echo $env:GITHUB_TOKEN                      # Windows PowerShell
 
 # 4. Add server
 /mcp add github
@@ -228,10 +231,19 @@ adal
 **How to verify**: After adding the server, AdaL will display "X tools available" (e.g., "26 tools available" for GitHub). This confirms your token is valid and the server is working.
 
 **Make it permanent** (survives terminal restarts):
+
+*macOS / Linux:*
 ```bash
 # Add to shell config (run once)
 echo 'export GITHUB_TOKEN="your_token_here"' >> ~/.zshrc
 source ~/.zshrc
+```
+
+*Windows PowerShell:*
+```powershell
+# Set as user environment variable (permanent)
+[System.Environment]::SetEnvironmentVariable('GITHUB_TOKEN', 'your_token_here', 'User')
+# Restart terminal to apply
 ```
 
 **Token storage**: API keys are stored in your **environment**, not by AdaL. AdaL reads them from env vars each time it starts.

--- a/docs-site/docs/03-features/keyboard-shortcuts.md
+++ b/docs-site/docs/03-features/keyboard-shortcuts.md
@@ -15,7 +15,6 @@ Quick reference for all keyboard shortcuts in AdaL CLI.
 | `Ctrl+E` | Move cursor to end of line   |
 | `Ctrl+U` | Clear from start to cursor   |
 | `Ctrl+K` | Clear from cursor to end     |
-| `Ctrl+W` | Delete word before cursor    |
 | `Ctrl+L` | Clear screen (display only)  |
 
 ## History Navigation


### PR DESCRIPTION
## Summary

Minor documentation fixes.

## Changes

- **MCP docs**: Add Windows PowerShell alternatives for setting `GITHUB_TOKEN` environment variable
- **Keyboard shortcuts**: Remove `Ctrl+W` (not available in AdaL)

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)