### PR TITLE
fix: update navbar links to fix broken / path

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -58,10 +58,11 @@ const config: Config = {
         alt: 'AdaL Logo',
         src: 'logo.png',
         srcDark: 'logo_dark.png',
+        href: '/getting-started/welcome',
       },
       items: [
         {
-          to: '/',
+          to: '/getting-started/welcome',
           label: 'Get Started',
           position: 'left',
         },


### PR DESCRIPTION
## Summary

Fixes the Docusaurus build failure caused by broken links to `/`.

## Changes

- Changed Get Started navbar link from `/` to `/getting-started/welcome`
- Added `href` to navbar logo to point to `/getting-started/welcome`

The root `/` path was broken because there is no index page in the docs folder when using `routeBasePath: \"/\"`.

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)