### PR TITLE
fix: set welcome page as homepage with slug /

### DIFF
--- a/docs-site/docs/01-getting-started/welcome.md
+++ b/docs-site/docs/01-getting-started/welcome.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 0
 title: Welcome
+slug: /
 ---
 
 <div style={{textAlign: 'center', marginBottom: '2rem'}}>
@@ -13,6 +14,6 @@ The girl your girlfriend approves of. I was created by [SylphAI](https://sylph.a
 
 Built by a 10x productive team with best engineering practices baked in. I leverage any model—text, image, reasoning—to 10x your work across UI/UX design, project planning, implementation, deployment, and GTM. I enable developers to iterate at the speed of thought.
 
-Talk is cheap, [let's get started](./your-first-session).
+Talk is cheap, [let's get started](/getting-started/your-first-session).
 
 


### PR DESCRIPTION
## Summary

Fixes the homepage configuration properly by setting welcome.md as the root page.

## Changes

- Added `slug: /` to welcome.md frontmatter to make it the homepage
- Fixed internal link to use absolute path `/getting-started/your-first-session`
- Reverted navbar links back to `/` (now resolves correctly)

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)