### PR TITLE
fix: add category link to fix broken /getting-started/welcome links

### DIFF
--- a/docs-site/docs/01-getting-started/_category_.json
+++ b/docs-site/docs/01-getting-started/_category_.json
@@ -1,4 +1,8 @@
 {
   "label": "Get Started",
-  "position": 1
+  "position": 1,
+  "link": {
+    "type": "doc",
+    "id": "getting-started/welcome"
+  }
 }

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -19,7 +19,12 @@ const config: Config = {
   projectName: 'adal-cli', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
## Summary

Fixes broken breadcrumb/sidebar links to `/getting-started/welcome`.

## Changes

- Added `link` property to `_category_.json` that points to the `getting-started/welcome` doc (which has `slug: /`)
- This resolves broken links generated by Docusaurus for category navigation

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)