### PR TITLE
fix: remove category link to prevent broken /getting-started/welcome path

### DIFF
--- a/docs-site/docs/01-getting-started/_category_.json
+++ b/docs-site/docs/01-getting-started/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "Get Started",
   "position": 1,
-  "link": {
-    "type": "doc",
-    "id": "getting-started/welcome"
-  }
+  "link": null
 }


### PR DESCRIPTION
## Summary

Fixes Render deployment failure caused by broken links to `/getting-started/welcome`.

## Root Cause

The category link with `type: "doc"` was resolving to the file path (`/getting-started/welcome`) instead of the doc's custom slug (`/`).

## Fix

Set `link: null` to remove the category link, allowing the sidebar to work without generating broken paths.

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)