### PR TITLE
fix: add slug to changelog for correct navbar link

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 99
 title: Changelog
+slug: /changelog
 ---
 
 # Changelog


### PR DESCRIPTION
## Summary

Fixes the Render deployment failure caused by broken `/changelog` link in navbar.

## Changes

- Added `slug: /changelog` to CHANGELOG.md frontmatter
- Ensures navbar link matches the generated page path

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)