### PR TITLE
docs: add web search capabilities guide

### DIFF
--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -149,14 +149,16 @@ Create a meaningful commit message and push to origin
 
 ## Thinking Mode
 
-Press `Tab` or use keywords:
-```
-Think deeply about how to optimize this algorithm
+Extended reasoning for complex tasks. **Powerful but token-intensive.**
 
-Reason carefully about security implications
+**Enable on-demand:**
+- **Keywords**: "think hard", "think deeply", "reason carefully"
+  ```
+  > debug this auth error, think hard
+  ```
+- **Tab shortcut**: Toggle mid-task. Takes effect at the next step—no need to cancel your query.
 
-Analyze thoroughly the performance bottlenecks
-```
+**Tip:** Reserve for complex debugging, architecture decisions, or when initial responses miss the mark.
 
 ---
 

--- a/docs-site/docs/03-features/web-search.md
+++ b/docs-site/docs/03-features/web-search.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 6
+---
+
+# Web Search
+
+AdaL can search the web for real-time information using multiple search types.
+
+## Supported Search Types
+
+| Type | Description | Example Query |
+|------|-------------|---------------|
+| `search` | General web search | "latest AI research" |
+| `scholar` | Academic papers | "transformer architecture papers" |
+| `news` | Recent news articles | "tech industry news today" |
+| `images` | Image search | "architecture diagrams" |
+| `videos` | Video search | "machine learning tutorials" |
+| `places` | Location search | "coffee shops near me" |
+| `shopping` | Product search | "mechanical keyboards" |
+| `patents` | Patent search | "battery technology patents" |
+
+## Usage
+
+Simply ask AdaL to search for information:
+
+```
+Search for recent developments in quantum computing
+Find academic papers on attention mechanisms
+Look up news about AI regulations
+```
+
+AdaL will automatically select the appropriate search type based on your query, or you can specify one explicitly.
+
+## Related
+
+- [Slash Commands](./slash-commands.md)
+- [Plugins and Skills](./plugins-and-skills.md)


### PR DESCRIPTION
## Summary

Add documentation for web search capabilities.

## Changes

- Add `docs/03-features/web-search.md` with all 8 supported search types
- Table with search types, descriptions, and example queries
- Usage examples and related links

## Supported Search Types

- search (general web)
- scholar (academic papers)
- news
- images
- videos
- places
- shopping
- patents

🌸 Generated with [AdaL](https://github.com/SylphAI-Inc/adal)