### PR TITLE
docs: update CHANGELOG for v0.4.0 in docs-site

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.4.0] - 2026-01-07
+- Supported more Linux distributions
+- Added Plan Mode (Ctrl+P) for planning-first workflows
+- Added google-gemini-3-flash-preview (/model)
+- Removed google-gemini-flash-2.5 and gpt-4o
+
 ## [0.3.5] - 2026-01-05
 - Faster query response
 - Supported more general web content for websearch, including images, places, and more


### PR DESCRIPTION
## Summary
Updated the changelog for v0.4.0 and improved docs:

### Changelog
- Added Plan Mode (Ctrl+P) entry
- Added google-gemini-3-flash-preview
- Removed google-gemini-flash-2.5 and gpt-4o
- Supported more Linux distributions

### Docs Improvements
- Added comprehensive Plan Mode explanation to keyboard shortcuts
- Removed duplicate MCP content (build-with-adal section)
- Cleaned up docs sidebar

🌸 Generated with [AdaL](https://github.com/adal-cli/)