### PR TITLE
Refine docs site: logos, code blocks, models, input methods, terminal setup

### DIFF
--- a/docs-site/docs/01-getting-started/input-methods.md
+++ b/docs-site/docs/01-getting-started/input-methods.md
@@ -13,6 +13,9 @@ This guide shows you different ways to provide content when using AdaL CLI.
 - **Type/Paste** - Platform-specific (⌘V vs Ctrl+V)
 - **@ References** - Universal (images, files, directories)
 - **Drag & Drop** - Shows path, agent reads
+- **Click to Position** - Click anywhere to move cursor
+- **History** - Up/Down arrows for previous messages
+- **Clear Input** - Press ESC when idle to clear all input
 
 ## @ References (Universal)
 
@@ -35,6 +38,18 @@ Type `@` followed by a path to include images, files, or directories. Works on *
 **Type Directly**
 - Simply type your question or message
 - Best for short queries and commands
+
+**Cursor Navigation**
+- Click anywhere in your input to position the cursor
+
+**Multi-line Input**
+- Press `Shift+Enter` to add new lines (Mac VS Code terminal)
+
+**Navigate History**
+- Use `Up/Down` arrows to navigate through previous messages
+
+**Clear Input**
+- Press `ESC` when idle to clear all input
 
 **Copy & Paste**
 - **Short text**: Appears exactly as pasted

--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -15,22 +15,20 @@ AdaL gives you access to the best AI models from leading providers—all in one 
 
 Select from frontier models optimized for engineering tasks:
 
-![Model Selection](/img/getting-started/model-selection.png)
+```
+> Select Model
+
+  ○ 1. Claude Sonnet 4.5         Anthropic • Thinking • 200K tokens • Default
+  ○ 2. Claude Haiku 4.5          Anthropic • Thinking • 200K tokens • Fast
+  ○ 3. Claude Sonnet 4.5 (1M)    Anthropic • Thinking • 1M tokens
+  ● 4. Claude Opus 4.5           Anthropic • Thinking • 200K tokens
+  ○ 5. Gemini 3 Pro (Preview)    Google • Thinking • 1M tokens
+  ○ 6. Gemini 3 Flash (Preview)  Google • Thinking • 1M tokens • Fast
+  ○ 7. Gemini 2.5 Pro            Google • Thinking • 1M tokens
+  ○ 8. GPT-4.1                   OpenAI • 1M tokens
+```
 
 Your selection persists for the current project.
-
-## Supported Providers
-
-| Provider | Models Available | Key Strength |
-|----------|-----------------|--------------|
-| **Anthropic** | Claude Opus 4.5, Sonnet 4.5, Haiku 4.5 | Extended thinking, 90% cache discount |
-| **Google** | Gemini 3 Pro, 3 Flash, 2.5 Pro | Multimodal, 1M context, ultra-fast |
-| **OpenAI** | GPT-4.1 | 1M context, coding-optimized |
-
-### Coming Soon
-- **GPT-5.2** - Next-gen OpenAI reasoning model
-- **GPT-5-Codex** - Specialized coding variant
-- **Ollama** - Open source local models (FREE, runs offline)
 
 ## Pricing
 
@@ -38,35 +36,40 @@ All pricing shown per **million tokens (MTok)**. Caching significantly reduces c
 
 ### Flagship Models
 
-| Model | Input ($/M) | Output ($/M) | Cache Discount | Best For |
-|-------|-------------|--------------|----------------|----------|
-| **Claude Opus 4.5** | $5 | $25 | 90% off | Complex reasoning, production code |
-| **Claude Sonnet 4.5** | $3 | $15 | 90% off | Daily coding, thinking mode, best value |
-| **Claude Sonnet 4.5 (1M)** | $6 | $22.50 | 90% off | Extended context for large codebases |
-| **Gemini 3 Pro** | $2 | $12 | 75% off | Multimodal reasoning, 1M context |
-| **Gemini 2.5 Pro** | $1.25 | $10 | 75% off | Multimodal reasoning, 1M context |
+| Model | Provider | Input ($/M) | Output ($/M) | Cache | Best For |
+|-------|----------|-------------|--------------|-------|----------|
+| **Claude Opus 4.5** | Anthropic | $5 | $25 | 90% off | Complex reasoning, production code |
+| **Claude Sonnet 4.5** | Anthropic | $3 | $15 | 90% off | Daily coding, thinking mode|
+| **Claude Sonnet 4.5 (1M)** | Anthropic | $6 | $22.50 | 90% off | Extended context for large codebases |
+| **Gemini 3 Pro** | Google | $2 | $12 | 75% off | Multimodal reasoning, 1M context |
+| **Gemini 2.5 Pro** | Google | $1.25 | $10 | 75% off | Multimodal reasoning, 1M context |
 
 ### Mid-Tier Models
 
-| Model | Input ($/M) | Output ($/M) | Cache Discount | Best For |
-|-------|-------------|--------------|----------------|----------|
-| **GPT-4.1** | $2 | $8 | 75% off | 1M context, large codebases |
+| Model | Provider | Input ($/M) | Output ($/M) | Cache | Best For |
+|-------|----------|-------------|--------------|-------|----------|
+| **GPT-4.1** | OpenAI | $2 | $8 | 75% off | 1M context, large codebases |
 
 ### Budget Models
 
-| Model | Input ($/M) | Output ($/M) | Cache Discount | Best For |
-|-------|-------------|--------------|----------------|----------|
-| **Gemini 3 Flash** | $0.50 | $3 | 90% off | Quick tasks, 1M context |
-| **Claude Haiku 4.5** | $1 | $5 | 90% off | Quick tasks |
+| Model | Provider | Input ($/M) | Output ($/M) | Cache | Best For |
+|-------|----------|-------------|--------------|-------|----------|
+| **Gemini 3 Flash** | Google | $0.50 | $3 | 90% off | Ultra-fast, 1M context |
+| **Claude Haiku 4.5** | Anthropic | $1 | $5 | 90% off | Quick tasks |
+
+<!-- ### Coming Soon
+- **GPT-5.2** (OpenAI) - Next-gen reasoning model
+- **GPT-5-Codex** (OpenAI) - Specialized coding variant
+- **Ollama** - Open source local models (FREE, runs offline) -->
 
 
 ## Key Features
 
 ### Thinking Models
-Models with extended reasoning (Claude Sonnet/Opus 4.5, Gemini 3 Pro/2.5 Pro, etc.) automatically break down complex problems before answering. Perfect for debugging, architecture decisions, and complex refactoring.
+Models with extended reasoning (Claude Sonnet/Opus 4.5, Gemini 3 Pro/2.5 Pro, etc.) automatically break down complex problems before answering. Perfect for debugging, architecture decisions, and complex refactoring. Toggle thinking mode with `Tab`.
 
 ### Prompt Caching
-Reusing context (files, conversation history) costs **50-90% less** with cached inputs. Caching is automatic—AdaL handles it behind the scenes.
+Reusing context (files, conversation history) costs **50-90% less** with cached inputs. Caching is automatic - AdaL handles it behind the scenes.
 
 ### Extended Context
 Handle large codebases with models supporting up to **1M tokens**:

--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -43,7 +43,7 @@ First run opens browser for authentication, then you're ready.
 | `/help` | Show all commands |
 | `/model` | Switch AI model |
 | `/init` | Generate project context (AGENTS.md) |
-| `/clear` | Clear conversation |
+| `/resume` | Resume a previous conversation |
 | `/compact` | Compress memory when full |
 | `/quit` or `Ctrl+C` | Exit |
 
@@ -51,18 +51,18 @@ First run opens browser for authentication, then you're ready.
 
 | Shortcut | What it does |
 |----------|--------------|
+| `?` | Show all shortcuts |
 | `Tab` | Toggle thinking mode |
 | `Shift+Tab` | Toggle auto-accept edits |
 | `Ctrl+P` | Toggle plan mode |
 | `ESC` | Cancel/reject |
-| `?` | Show all shortcuts |
 
 ## Essential Prefixes
 
 | Prefix | What it does | Example |
 |--------|--------------|---------|
 | `@` | Target specific file as context | `@src/api.ts add validation` |
-| `!` | Run shell command | `!npm test` |
+| `!` | Run shell command | `!git status` |
 
 
 ## What's Next?

--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -17,7 +17,7 @@ npm install -g @sylphai/adal-cli
 
 ## Launch
 
-Open any terminal—macOS Terminal, Linux shell, or an IDE terminal like VS Code—then `cd` to your working directory and run:
+Open any terminal (VS Code, iTerm, PowerShell, Linux shell, etc.) and then `cd` to your working directory and run:
 
 ```bash
 adal

--- a/docs-site/docs/01-getting-started/welcome.md
+++ b/docs-site/docs/01-getting-started/welcome.md
@@ -4,15 +4,16 @@ title: Welcome
 slug: /
 ---
 
-<div style={{textAlign: 'center', marginBottom: '3rem', marginTop: '2rem'}}>
-  <img src="/img/adal-mascot-with-bg.png" alt="AdaL Mascot" style={{maxWidth: '500px', width: '100%', display: 'block', margin: '0 auto', borderRadius: '20px', border: 'none', outline: 'none', boxShadow: 'none'}} />
+<div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '2rem', marginBottom: '3rem', marginTop: '2rem', flexWrap: 'wrap'}}>
+  <img src="/adal-face-logo.svg" alt="AdaL Face Logo" style={{height: '120px', width: 'auto', border: 'none', outline: 'none', boxShadow: 'none'}} />
+  <img src="/adal-text-logo.svg" alt="AdaL Text Logo" style={{height: '120px', width: 'auto', border: 'none', outline: 'none', boxShadow: 'none'}} />
 </div>
 
 # Hi, I'm AdaL
 
-The girl your girlfriend approves of. I was created by [SylphAI](https://sylph.ai) and named after Ada Lovelace, the world's first programmer. Follow me on [GitHub](https://github.com/adal-cli).
+I was created by [SylphAI](https://sylph.ai) and named after Ada Lovelace, the world's first programmer.
 
-Built by a 10x productive team with best engineering practices baked in. I leverage any model—text, image, reasoning—to 10x your work across UI/UX design, project planning, implementation, deployment, and GTM. I enable developers to iterate at the speed of thought.
+Built by a 10x productive team with best engineering practices baked in. I leverage any model-text, image, reasoning-to 10x your work across UI/UX design, project planning, implementation, deployment, and GTM. I enable developers to iterate at the speed of thought. Follow me on [GitHub](https://github.com/adal-cli).
 
 Talk is cheap, [let's get started](/getting-started/quickstart).
 

--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -16,6 +16,25 @@ Practical patterns for everyday development.
 
 **Tip:** A larger terminal window gives AdaL more room to display code and diffs clearly.
 
+### Truecolor Support
+
+AdaL themes require **truecolor (24-bit color)** for accurate rendering. Most modern terminals support this by default.
+
+**Check your terminal:**
+```bash
+echo $COLORTERM
+```
+Output should be `truecolor` or `24bit`.
+
+**Enable truecolor:** Add to your shell profile (`.zshrc`, `.bashrc`):
+```bash
+export COLORTERM=truecolor
+```
+
+:::tip macOS Native Terminal
+If colors appear off in the macOS Terminal app, upgrade to macOS 26+ for full truecolor support, or use iTerm2 / VS Code terminal instead.
+:::
+
 
 ## Set Up Project Context
 
@@ -145,7 +164,7 @@ Extended reasoning for complex tasks. **Powerful but token-intensive.**
   ```
   > debug this auth error, think hard
   ```
-- **Tab shortcut**: Toggle mid-task. Takes effect at the next step—no need to cancel your query.
+- **Tab shortcut**: Toggle mid-task. Takes effect at the next step — no need to cancel your query.
 
 **Tip:** Reserve for complex debugging, architecture decisions, or when initial responses miss the mark.
 
@@ -167,7 +186,7 @@ Keep your session focused and clean:
 - `/clear` — Switching to unrelated task
 - `/compact` — Long session getting slow, want to continue same work
 
-
+<!-- 
 ## Parallel Sessions (Git Worktrees)
 
 ```bash
@@ -190,7 +209,7 @@ npm test 2>&1 | adal --question "Why are tests failing?"
 
 # Pipe output
 adal --question "Create a user schema" > schema.prisma
-```
+``` -->
 
 
 

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.5.0] - 2026-01-13
+- New UI: more stable, no flashing, no flickering, faster performance throughout the session
+- Improved input experience: cursor navigation, Shift+Enter for multi-line input, better query history navigation via up/down arrow
+- New logo and header design
+- Simplified /theme
+- Better markdown formatting and table rendering
+- Enhanced image understanding
+- Improved /compact
+- Enhanced /changelog with more history and link to documentation
+- Fixed auto-edit UI not updating after Shift+Tab or option selection during edit confirmations
+
 ## [0.4.0] - 2026-01-07
 - Supported more Linux distributions
 - Added Plan Mode (Ctrl+P) for planning-first workflows

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -66,8 +66,7 @@ const config: Config = {
       logo: {
         alt: 'AdaL Logo',
         src: 'adal-face-logo.svg',
-        srcDark: 'logo_dark.png',
-
+        srcDark: 'adal-face-logo.svg',
       },
       items: [
         {

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'AdaL',
   tagline: 'Your Agentic Coding Tool in Terminal',
-  favicon: 'logo.png',
+  favicon: 'adal-face-logo.svg',
 
   // Set the production url of your site here
   url: 'https://adal-cli-docs.onrender.com',
@@ -62,11 +62,12 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: 'AdaL',
+      title: '',
       logo: {
         alt: 'AdaL Logo',
-        src: 'logo.png',
+        src: 'adal-face-logo.svg',
         srcDark: 'logo_dark.png',
+
       },
       items: [
         {
@@ -148,6 +149,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['bash', 'json', 'yaml', 'typescript', 'python', 'markdown', 'diff'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -542,11 +542,19 @@ h3:hover .hash-link {
 }
 
 /* ===== CODE BLOCKS - Enhanced ===== */
+/* Code block container wrapper */
+[class*="codeBlockContainer"],
+[class*="codeBlock_"] {
+  border-radius: 12px !important;
+  overflow: hidden;
+}
+
 pre {
-  border-radius: 10px !important;
+  border-radius: 12px !important;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 1rem !important;
-  margin: 1.5rem 0;
+  padding: 0.15rem 0.35rem !important;
+  margin: 0.2rem 0;
+  line-height: 1.2;
 }
 
 [data-theme='dark'] pre {

--- a/docs-site/static/adal-face-logo.svg
+++ b/docs-site/static/adal-face-logo.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 184" fill="none">
+  <style>
+        .line { stroke: #66C76F; stroke-width: 2; stroke-linecap: square; }
+        .fill { fill: #66C76F; stroke: none; }
+        .symbol { stroke: #66C76F; stroke-width: 2; fill: none; }
+    </style>
+  <g transform="translate(20, 20)">
+    <g transform="translate(0, 0)">
+      <path d="M 9.5,48 V 21.5 H 24 M 14.5,48 V 26.5 H 24" class="line" />
+    </g>
+    <g transform="translate(24, 0)">
+      <path d="M 0,21.5 H 24 M 0,26.5 H 24" class="line" />
+    </g>
+    <g transform="translate(48, 0)">
+      <rect x="0" y="0" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(72, 0)">
+      <rect x="0" y="0" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(96, 0)">
+      <rect x="0" y="0" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(120, 0)">
+      <rect x="0" y="0" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(144, 0)">
+      <rect x="0" y="0" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(168, 0)">
+      <path d="M 0,21.5 H 24 M 0,26.5 H 24" class="line" />
+    </g>
+    <g transform="translate(192, 0)">
+      <path d="M 14.5,48 V 21.5 H 0 M 9.5,48 V 26.5 H 0" class="line" />
+    </g>
+    <g transform="translate(0, 48)">
+      <path d="M 9.5,0 V 48 M 14.5,0 V 48" class="line" />
+    </g>
+    <g transform="translate(24, 48)" />
+    <g transform="translate(48, 48)">
+      <path d="M 3.0,13.5 L 21.0,24.0 L 3.0,34.5" class="symbol" stroke-linejoin="round" />
+    </g>
+    <g transform="translate(72, 48)" />
+    <g transform="translate(96, 48)" />
+    <g transform="translate(120, 48)" />
+    <g transform="translate(144, 48)">
+      <circle cx="12.0" cy="24.0" r="12" class="symbol" />
+      <path d="M 12.0,12.0 A 12,12 0 0,1 12.0,36.0 Z" class="fill" />
+    </g>
+    <g transform="translate(168, 48)" />
+    <g transform="translate(192, 48)">
+      <path d="M 9.5,0 V 48 M 14.5,0 V 48" class="line" />
+    </g>
+    <g transform="translate(0, 96)">
+      <path d="M 9.5,0 V 26.5 H 24 M 14.5,0 V 21.5 H 24" class="line" />
+    </g>
+    <g transform="translate(24, 96)">
+      <path d="M 0,21.5 H 24 M 0,26.5 H 24" class="line" />
+    </g>
+    <g transform="translate(48, 96)">
+      <rect x="0" y="23.5" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(72, 96)">
+      <rect x="0" y="23.5" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(96, 96)">
+      <rect x="0" y="23.5" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(120, 96)">
+      <rect x="0" y="23.5" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(144, 96)">
+      <rect x="0" y="23.5" width="25.0" height="24.5" class="fill" />
+    </g>
+    <g transform="translate(168, 96)">
+      <path d="M 0,21.5 H 24 M 0,26.5 H 24" class="line" />
+    </g>
+    <g transform="translate(192, 96)">
+      <path d="M 14.5,0 V 26.5 H 0 M 9.5,0 V 21.5 H 0" class="line" />
+    </g>
+  </g>
+</svg>

--- a/docs-site/static/adal-text-logo.svg
+++ b/docs-site/static/adal-text-logo.svg
@@ -1,0 +1,124 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 472 184" fill="none">
+  <style>.fill { fill: #66C76F; }</style>
+  <g transform="translate(20, 20)">
+    <g transform="translate(0, 0)">
+      <rect x="0" y="23.0" width="25.0" height="26.0" class="fill" />
+    </g>
+    <g transform="translate(24, 0)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(48, 0)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(72, 0)">
+      <rect x="0" y="23.0" width="25.0" height="26.0" class="fill" />
+    </g>
+    <g transform="translate(96, 0)" />
+    <g transform="translate(120, 0)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(144, 0)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(168, 0)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(192, 0)">
+      <rect x="0" y="23.0" width="25.0" height="26.0" class="fill" />
+    </g>
+    <g transform="translate(216, 0)" />
+    <g transform="translate(240, 0)">
+      <rect x="0" y="23.0" width="25.0" height="26.0" class="fill" />
+    </g>
+    <g transform="translate(264, 0)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(288, 0)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(312, 0)">
+      <rect x="0" y="23.0" width="25.0" height="26.0" class="fill" />
+    </g>
+    <g transform="translate(336, 0)" />
+    <g transform="translate(360, 0)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(0, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(24, 48)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(48, 48)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(72, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(96, 48)" />
+    <g transform="translate(120, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(144, 48)" />
+    <g transform="translate(168, 48)" />
+    <g transform="translate(192, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(216, 48)" />
+    <g transform="translate(240, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(264, 48)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(288, 48)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(312, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(336, 48)" />
+    <g transform="translate(360, 48)">
+      <rect x="0" y="0" width="25.0" height="49.0" class="fill" />
+    </g>
+    <g transform="translate(0, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(24, 96)" />
+    <g transform="translate(48, 96)" />
+    <g transform="translate(72, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(96, 96)" />
+    <g transform="translate(120, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(144, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(168, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(192, 96)" />
+    <g transform="translate(216, 96)" />
+    <g transform="translate(240, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(264, 96)" />
+    <g transform="translate(288, 96)" />
+    <g transform="translate(312, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(336, 96)" />
+    <g transform="translate(360, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(384, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+    <g transform="translate(408, 96)">
+      <rect x="0" y="0" width="25.0" height="25.0" class="fill" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Documentation refinements for v0.5.0 release.

## Changes

### Welcome Page
- Add adal-face-logo.svg and adal-text-logo.svg side-by-side
- Lighten SVG colors from #3CA84B to #66C76F
- Fix dark mode navbar logo

### Code Blocks
- Tighten padding and margins for compact display
- Add 12px rounded corners with container wrapper
- Add additional Prism languages (bash, json, yaml, typescript, python, markdown, diff)

### Models & Pricing Page
- Replace model selection screenshot with styled code block
- Merge Supported Providers into pricing tables with Provider column
- Add thinking mode toggle instruction

### Input Methods
- Add cursor navigation, multi-line input, history navigation, clear input features
- Update Quick Overview section

### Workflows & Examples
- Add Truecolor Support section for terminal setup
- Include instructions for checking and enabling 24-bit color

🌸 Generated with [AdaL](https://github.com/adal-cli/)