### PR TITLE
docs: remove Alias column from slash commands

### DIFF
--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -9,27 +9,27 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 
 ## Quick Reference
 
-| Command         | Alias       | Description                  |
-| --------------- | ----------- | ---------------------------- |
-| `/help`         | `/?`        | Show help information        |
-| `/changelog`    | -           | Show recent changes          |
-| `/model`        | -           | Switch AI model              |
-| `/clear`        | -           | Clear conversation history   |
-| `/resume`       | `/sessions` | Resume previous session      |
-| `/init [optional msg]`   | -           | Generate AGENTS.md file      |
-| `/compact`      | -           | Compress conversation memory |
-| `/stats`        | `/usage`    | Show session statistics      |
-| `/mcp`          | -           | Manage MCP servers           |
-| `/bashes`       | -           | List background processes    |
-| `/auth`         | -           | Show auth status             |
-| `/logout`       | -           | Sign out and exit            |
-| `/quit`         | `/exit`     | Exit AdaL CLI                |
-| `/theme`        | -           | Change theme                 |
-| `/about`        | -           | Show version info            |
-| `/bug [desc]`   | -           | Report a bug                 |
-| `/byoak`        | -           | Bring your own API keys     |
-| `/skills`       | -           | List loaded skills           |
-| `/plugin`       | -           | Manage plugins/marketplaces  |
+| Command                | Description                  |
+| ---------------------- | ---------------------------- |
+| `/help`                | Show help information        |
+| `/changelog`           | Show recent changes          |
+| `/model`               | Switch AI model              |
+| `/clear`               | Clear conversation history   |
+| `/resume`              | Resume previous session      |
+| `/init [optional msg]` | Generate AGENTS.md file      |
+| `/compact`             | Compress conversation memory |
+| `/stats`               | Show session statistics      |
+| `/mcp`                 | Manage MCP servers           |
+| `/bashes`              | List background processes    |
+| `/auth`                | Show auth status             |
+| `/logout`              | Sign out and exit            |
+| `/quit`                | Exit AdaL CLI                |
+| `/theme`               | Change theme                 |
+| `/about`               | Show version info            |
+| `/bug [desc]`          | Report a bug                 |
+| `/byoak`               | Bring your own API keys      |
+| `/skills`              | List loaded skills           |
+| `/plugin`              | Manage plugins/marketplaces  |
 
 
 ## Tips


### PR DESCRIPTION
## Summary

Simplified the slash commands table by removing the Alias column - most aliases were just "-" anyway.

🌸 Generated with [AdaL](https://github.com/adal-cli/)