### PR TITLE
docs: add workspace management commands for parallel branch development

### DIFF
--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -47,16 +47,6 @@ First run opens browser for authentication, then you're ready.
 | `/compact` | Compress memory when full |
 | `/quit` | Exit |
 
-## Workspace Management
-
-Work on multiple branches in parallel:
-
-| Command | What it does |
-|---------|--------------|
-| `adal workspace create <name>` | Create new workspace |
-| `adal workspace list` | List all workspaces |
-| `adal workspace remove <name>` | Remove workspace |
-
 ## Essential Shortcuts
 
 | Shortcut | What it does |
@@ -74,6 +64,16 @@ Work on multiple branches in parallel:
 |--------|--------------|---------|
 | `@` | Target specific file as context | `@src/api.ts add validation` |
 | `!` | Run shell command | `!git status` |
+
+## Workspace Management
+
+Work on multiple branches in parallel:
+
+| Command | What it does |
+|---------|--------------|
+| `adal workspace create <name>` | Create new workspace |
+| `adal workspace list` | List all workspaces |
+| `adal workspace remove <name>` | Remove workspace |
 
 ## Terminal Setup
 

--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -47,6 +47,16 @@ First run opens browser for authentication, then you're ready.
 | `/compact` | Compress memory when full |
 | `/quit` | Exit |
 
+## Workspace Management
+
+Work on multiple branches in parallel:
+
+| Command | What it does |
+|---------|--------------|
+| `adal workspace create <name>` | Create new workspace |
+| `adal workspace list` | List all workspaces |
+| `adal workspace remove <name>` | Remove workspace |
+
 ## Essential Shortcuts
 
 | Shortcut | What it does |

--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -162,15 +162,21 @@ Keep your session focused and clean:
 ## Work on Multiple Branches
 
 ```bash
-# Terminal 1
+# Create workspace
 adal workspace create feature-auth
-cd ../adal-cli-feature-auth
-adal
+# ✓ Created workspace-feature-auth-main
+#   Path: /path/to/project/.adal_workspace/workspace-feature-auth
+#   Base: main
+#
+# To start working:
+#   cd /path/to/project/.adal_workspace/workspace-feature-auth && adal
 
-# Terminal 2
+# Start working in workspace
+cd .adal_workspace/workspace-feature-auth && adal
+
+# In another terminal, create second workspace
 adal workspace create feature-payments
-cd ../adal-cli-feature-payments
-adal
+cd .adal_workspace/workspace-feature-payments && adal
 
 # Check workspaces
 adal workspace list

--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -158,30 +158,26 @@ Keep your session focused and clean:
 - `/clear` — Switching to unrelated task
 - `/compact` — Long session getting slow, want to continue same work
 
-<!-- 
-## Parallel Sessions (Git Worktrees)
+
+## Work on Multiple Branches
 
 ```bash
 # Terminal 1
-git worktree add ../project-feature-a feature/user-auth
-cd ../project-feature-a && adal
+adal workspace create feature-auth
+cd ../adal-cli-feature-auth
+adal
 
 # Terminal 2
-git worktree add ../project-feature-b feature/payments
-cd ../project-feature-b && adal
+adal workspace create feature-payments
+cd ../adal-cli-feature-payments
+adal
+
+# Check workspaces
+adal workspace list
+
+# Remove when done
+adal workspace remove feature-auth
 ```
-
-
-## Unix-Style Usage
-
-```bash
-# Pipe input
-git diff | adal --question "Explain these changes"
-npm test 2>&1 | adal --question "Why are tests failing?"
-
-# Pipe output
-adal --question "Create a user schema" > schema.prisma
-``` -->
 
 
 

--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -161,6 +161,8 @@ Keep your session focused and clean:
 
 ## Work on Multiple Branches
 
+Create isolated workspaces to work on different features simultaneously without switching branches:
+
 ```bash
 # Create workspace
 adal workspace create feature-auth

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -19,12 +19,7 @@ const config: Config = {
   projectName: 'adal-cli', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-
-  markdown: {
-    hooks: {
-      onBrokenMarkdownLinks: 'warn',
-    },
-  },
+  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
Add documentation for adal workspace CLI commands that enable working on multiple branches simultaneously using Git worktrees. Updated quickstart guide with workspace management section and workflows with practical examples.