### PR TITLE
docs: update for v0.6.3 - remove thinking toggle, update model pool

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -18,17 +18,18 @@ Select from frontier models optimized for engineering tasks:
 ```
 > Select Model
 
-  ○ 1. Claude Sonnet 4.5         Anthropic • Thinking • 200K tokens • Default
-  ○ 2. Claude Haiku 4.5          Anthropic • Thinking • 200K tokens • Fast
-  ○ 3. Claude Sonnet 4.5 (1M)    Anthropic • Thinking • 1M tokens
-  ● 4. Claude Opus 4.5           Anthropic • Thinking • 200K tokens
-  ○ 5. Gemini 3 Pro (Preview)    Google • Thinking • 1M tokens
-  ○ 6. Gemini 3 Flash (Preview)  Google • Thinking • 1M tokens • Fast
-  ○ 7. Gemini 2.5 Pro            Google • Thinking • 1M tokens
-  ○ 8. GPT-4.1                   OpenAI • 1M tokens
+  ● 1. Claude Opus 4.5           Anthropic • 200K tokens • Default
+  ○ 2. Claude Opus 4.6           Anthropic • 200K tokens • New
+  ○ 3. Claude Opus 4.6 (1M)      Anthropic • 1M tokens • New
+  ○ 4. Claude Sonnet 4.5         Anthropic • 200K tokens
+  ○ 5. Claude Haiku 4.5          Anthropic • 200K tokens • Fast
+  ○ 6. Gemini 3 Pro              Google • 1M tokens
+  ○ 7. Gemini 3 Flash            Google • 1M tokens • Fast
+  ○ 8. Gemini 2.5 Pro            Google • 1M tokens
+  ○ 9. GPT-4.1                   OpenAI • 1M tokens
 ```
 
-Your selection persists for the current project.
+Your selection also applies to future AdaL CLI sessions in this project.
 
 ## Pricing
 
@@ -39,8 +40,9 @@ All pricing shown per **million tokens (MTok)**. Caching significantly reduces c
 | Model | Provider | Input ($/M) | Output ($/M) | Cache | Best For |
 |-------|----------|-------------|--------------|-------|----------|
 | **Claude Opus 4.5** | Anthropic | $5 | $25 | 90% off | Complex reasoning, production code |
-| **Claude Sonnet 4.5** | Anthropic | $3 | $15 | 90% off | Daily coding, thinking mode|
-| **Claude Sonnet 4.5 (1M)** | Anthropic | $6 | $22.50 | 90% off | Extended context for large codebases |
+| **Claude Opus 4.6** | Anthropic | $5 | $25 | 90% off | Latest reasoning, production code |
+| **Claude Opus 4.6 (1M)** | Anthropic | $10 | $37.50 | 90% off | Extended context for large codebases |
+| **Claude Sonnet 4.5** | Anthropic | $3 | $15 | 90% off | Daily coding, balanced cost |
 | **Gemini 3 Pro** | Google | $2 | $12 | 75% off | Multimodal reasoning, 1M context |
 | **Gemini 2.5 Pro** | Google | $1.25 | $10 | 75% off | Multimodal reasoning, 1M context |
 
@@ -65,17 +67,17 @@ All pricing shown per **million tokens (MTok)**. Caching significantly reduces c
 
 ## Key Features
 
-### Thinking Models
-Models with extended reasoning (Claude Sonnet/Opus 4.5, Gemini 3 Pro/2.5 Pro, etc.) automatically break down complex problems before answering. Perfect for debugging, architecture decisions, and complex refactoring. Toggle thinking mode with `Tab`.
+### Adaptive Thinking
+All models use adaptive thinking that automatically scales reasoning depth based on task complexity. There's no toggle—thinking is always on and adjusts itself. Perfect for debugging, architecture decisions, and complex refactoring.
 
 ### Prompt Caching
 Reusing context (files, conversation history) costs **50-90% less** with cached inputs. Caching is automatic - AdaL handles it behind the scenes.
 
 ### Extended Context
 Handle large codebases with models supporting up to **1M tokens**:
-- Claude Sonnet 4.5 (1M)
+- Claude Opus 4.6 (1M)
 - Gemini 3 Pro (1M)
-- Gemini 2.5 Flash (1M)
+- Gemini 2.5 Pro (1M)
 - GPT-4.1 (1M)
 
 Perfect for reviewing entire repositories or understanding complex systems.

--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -52,7 +52,6 @@ First run opens browser for authentication, then you're ready.
 | Shortcut | What it does |
 |----------|--------------|
 | `?` | Show all shortcuts |
-| `Tab` | Toggle thinking mode |
 | `Shift+Tab` | Toggle auto-accept edits |
 | `Ctrl+P` | Toggle plan mode |
 | `Ctrl+C` | Cancel agent streaming/running|

--- a/docs-site/docs/03-features/keyboard-shortcuts.md
+++ b/docs-site/docs/03-features/keyboard-shortcuts.md
@@ -36,7 +36,6 @@ Quick reference for all keyboard shortcuts in AdaL CLI.
 
 | Shortcut    | Action                                    |
 | ----------- | ----------------------------------------- |
-| `Tab`       | Toggle thinking mode (extended reasoning) |
 | `Shift+Tab` | Toggle auto-accept edit mode              |
 | `Ctrl+P`    | Toggle plan mode                          |
 | `Ctrl+R`    | Expand/collapse thinking content          |
@@ -44,30 +43,6 @@ Quick reference for all keyboard shortcuts in AdaL CLI.
 
 
 ## Mode Explanations
-
-### Thinking Mode (`Tab`)
-
-When enabled, AdaL shows its reasoning process:
-
-```
-[Thinking mode: ON]
-
-> How should I structure this authentication system?
-
-<thinking>
-- Need to consider security best practices
-- JWT vs session tokens
-- Password hashing algorithm choice
-- Rate limiting for login attempts
-</thinking>
-
-Here's my recommendation...
-```
-
-**When to enable:**
-- Complex architectural decisions
-- Debugging tricky issues
-- Performance optimization
 
 ### Auto-Accept Mode (`Shift+Tab`)
 

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.6.3] - 2026-02-05
+- Added Claude Opus 4.6 (1M context window)
+- Always-on adaptive thinking that removes the thinking toggle
+- Loading indicator UI improvements
+- Model tags and display name cleanup
+
 ## [0.6.2] - 2026-02-05
 - Added Claude Opus 4.6 day 1 support (/model)
 - Improved error handling and retry experience

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -111,16 +111,16 @@ const config: Config = {
           title: 'Community',
           items: [
             {
-              label: 'Follow AdaL',
-              href: 'https://x.com/adaboringai',
+              label: 'X (Twitter)',
+              href: 'https://x.com/adalengineer',
             },
             {
               label: 'Discord',
-              href: 'https://discord.gg/sylphai',
+              href: 'https://discord.com/invite/ezzszrRZvT',
             },
             {
-              label: 'GitHub Discussions',
-              href: 'https://github.com/SylphAI-Inc/adal/discussions',
+              label: 'GitHub',
+              href: 'https://github.com/SylphAI-Inc',
             },
           ],
         },


### PR DESCRIPTION
## Changes

- Remove Tab thinking toggle from quickstart and keyboard shortcuts
- Remove Thinking Mode section from keyboard shortcuts
- Update model pool: add Claude Opus 4.6 and Opus 4.6 (1M)
- Remove Thinking tags from all models, remove Preview from Gemini
- Rename Thinking Models to Adaptive Thinking
- Update extended context model list
- Update Follow AdaL link to https://x.com/adalengineer
- Changelog updates

🌸 Generated with [AdaL](https://github.com/adal-cli/)