### PR TITLE
docs: comprehensive README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,43 @@
   <img src="docs-site/static/adal-face-logo.svg" alt="AdaL Face" width="150" />
   &nbsp;&nbsp;&nbsp;&nbsp;
   <img src="docs-site/static/adal-text-logo.svg" alt="AdaL Text" width="280" />
-  <br />
-  <strong>Your CLI agent for engineering and research</strong>
   <br /><br />
-  
-  [View Docs](https://adal-cli-docs.onrender.com) · [Report Issue](#reporting-issues) · [Contribute](#contributing)
+  <strong>Your self-evolving agent for engineering and research</strong>
+  <br /><br />
+
+  [![Docs](https://img.shields.io/badge/docs-docs.sylph.ai-blue)](https://docs.sylph.ai)
+  [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/ezzszrRZvT)
+  [![X](https://img.shields.io/badge/follow-%40adalengineer-black?logo=x)](https://x.com/adalengineer)
 </div>
 
 ---
 
-## About This Repository
+## About
 
-This is the **public documentation site** for [AdaL CLI](https://github.com/SylphAI-Inc/adal-cli), built with Docusaurus. We welcome community contributions!
+This is the **public documentation site** for [AdaL CLI](https://docs.sylph.ai/). AdaL is an agentic coding tool that runs in your terminal, created by [SylphAI](https://sylph.ai/) and named after Ada Lovelace, the world's first programmer.
 
 **What you can do here:**
-- **Report issues** with AdaL CLI agent behavior
-- **Suggest documentation fixes** or improvements
-- **Contribute** to make the docs better
+
+- Report issues with AdaL CLI agent behavior
+- Suggest documentation fixes or improvements
+- Contribute to make the docs better
+
+### Install AdaL CLI
+
+```bash
+npm install -g @sylphai/adal-cli
+
+# cd to your working directory and run
+adal
+```
+
+Requires [Node.js 20+](https://nodejs.org/en/download). See [Quickstart](https://docs.sylph.ai/getting-started/quickstart) for details.
 
 ## 🐛 Reporting Issues
 
-Found a bug with AdaL CLI or notice something wrong in the docs?
+Found a bug or something wrong in the docs?
 
-**[Open an Issue](https://github.com/SylphAI-Inc/adal-cli/issues/new)**
+**[Open an Issue →](https://github.com/SylphAI-Inc/adal-cli/issues/new)**
 
 Please include:
 - What you expected vs what happened
@@ -36,61 +50,54 @@ Please include:
 
 ## 📝 Contributing
 
-We appreciate documentation improvements! Here's how:
+We welcome documentation improvements!
 
 ### Quick Edits
 
-1. Navigate to the doc you want to fix at [adal-cli-docs.onrender.com](https://adal-cli-docs.onrender.com)
-2. Note the page path (e.g., `/features/slash-commands`)
-3. Find the corresponding file in `docs-site/docs/`
-4. Edit and submit a PR
+1. Find the page you want to fix at [docs.sylph.ai](https://docs.sylph.ai)
+2. Locate the corresponding file in `docs-site/docs/`
+3. Edit and submit a PR
 
 ### Running Locally
 
 ```bash
 cd docs-site
-
-# Install dependencies
 npm install
-
-# Start development server (opens http://localhost:3000)
-npm run start
-
-# Build for production
-npm run build
+npm run start    # Dev server at http://localhost:3000
+npm run build    # Production build
 ```
 
-### Contribution Guidelines
+### Guidelines
 
 - Keep docs clear and concise
-- Test your changes locally with `npm run build`
+- Test changes locally with `npm run build`
 - Follow existing formatting conventions
 
-## Documentation Structure
+## Project Structure
 
 ```
 docs-site/
 ├── docs/                    # Documentation pages (markdown)
-│   ├── 01-getting-started/  # Quickstart, installation
-│   ├── 03-features/         # Feature documentation
-│   ├── 07-troubleshooting/  # Common issues
+│   ├── 01-getting-started/  # Quickstart, models, workflows
+│   ├── 03-features/         # Feature docs (shortcuts, commands, skills)
+│   ├── 07-troubleshooting/  # Common issues and solutions
 │   └── build-with-adal/     # Advanced usage
 ├── static/                  # Images and assets
-└── src/                     # React components, custom CSS
+└── src/                     # Custom CSS and components
 ```
 
 ## Links
 
-- **Docs Site:** [adal-cli-docs.onrender.com](https://adal-cli-docs.onrender.com)
-- **AdaL CLI:** [github.com/SylphAI-Inc/adal-cli](https://github.com/SylphAI-Inc/adal-cli)
-- **Follow AdaL:** [github.com/adal-cli](https://github.com/adal-cli)
+- **Docs:** [docs.sylph.ai](https://docs.sylph.ai)
+- **GitHub:** [github.com/SylphAI-Inc/adal-cli](https://github.com/SylphAI-Inc/adal-cli)
+- **X (Twitter):** [@adalengineer](https://x.com/adalengineer)
 - **Discord:** [Join our community](https://discord.com/invite/ezzszrRZvT)
+- **SylphAI:** [sylph.ai](https://sylph.ai)
 
 ---
 
 <div align="center">
-  <strong>Star <a href="https://github.com/SylphAI-Inc/adal-cli">AdaL CLI</a> · Follow <a href="https://github.com/adal-cli">AdaL</a></strong>
-  <br />
-  Documentation built by AdaL herself · Created by <a href="https://sylph.ai">SylphAI</a>
+  <!-- <strong>Star <a href="https://github.com/SylphAI-Inc/adal-cli">AdaL CLI</a> · Follow <a href="https://x.com/adalengineer">@adalengineer</a></strong>
+  <br /> -->
+  Built with <a href="https://docusaurus.io/">Docusaurus</a> by AdaL & <a href="https://sylph.ai">SylphAI</a>
 </div>
-

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   favicon: 'adal-face-logo.svg',
 
   // Set the production url of your site here
-  url: 'https://adal-cli-docs.onrender.com',
+  url: 'https://docs.sylph.ai',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For Render deployment, use root
   baseUrl: '/',


### PR DESCRIPTION
## Changes

- Comprehensive README rewrite with key highlights, badges, and quick install section
- Update docs site URL from adal-cli-docs.onrender.com to docs.sylph.ai
- Add X/Twitter @adalengineer link and static Discord badge
- Move Docusaurus mention from intro to footer
- Update tagline

🌸 Generated with [AdaL](https://github.com/adal-cli/)