### PR TITLE
docs: update models page for OpenAI + ChatGPT Subscription

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: Models & Billing
-description: "AdaL supports 24+ AI models — Claude Sonnet/Opus, GPT-5, Gemini 3, MiniMax, and local models via Ollama. Switch models instantly. Pay-per-token with prompt caching for 50-90% savings."
+description: "AdaL supports 20+ AI models — Claude Sonnet/Opus, GPT-5, Gemini 3, MiniMax, and local models via Ollama. Switch models instantly. Pay-per-token with prompt caching for 50-90% savings."
 ---
 
 # Models & Billing
@@ -19,24 +19,29 @@ Select from frontier models optimized for engineering tasks:
 ```
 > Select Model
 
-Switch AI model for this project. 24 models available
+Switch AI model for this project. 21 models available
 
 Recommended
 
-● Claude Sonnet 4.6 ✓     Anthropic • 200K
-○ Claude Opus 4.6         Anthropic • 200K
-○ Gemini 3.1 Pro          Google • 1M
-○ Gemini 3 Flash          Google • 1M
-○ GPT-5.2 Codex           OpenAI • 400K
-○ MiniMax M2.5            MiniMax • 200K
-○ MiniMax M2.5 Highspeed  MiniMax • 200K
+○ Claude Sonnet 4.6      Anthropic • 200K
+○ Claude Opus 4.6        Anthropic • 200K
+○ Gemini 3.1 Pro         Google • 1M
+○ Gemini 3 Flash         Google • 1M
+○ GPT-5.2 Codex          OpenAI • 400K
+○ MiniMax M2.5           MiniMax • 200K
+○ MiniMax M2.5 Highspeed MiniMax • 200K
 
 Providers
 
-○ Anthropic ✓           7 models →
-○ OpenAI               11 models →
-○ Google                4 models →
-○ MiniMax               2 models →
+○ Anthropic  7 models →
+○ OpenAI     6 models →
+○ Google     4 models →
+○ MiniMax    2 models →
+○ Ollama     2 models →
+
+Third Party Subscriptions
+
+○ ChatGPT Subscription  Connected →
 
 ↑↓ navigate · Enter select/open · Press i for info · Esc exit
 ```
@@ -69,19 +74,14 @@ These are our top picks, balancing capability, speed, and cost:
 - **Claude Opus 4.5** — Previous generation flagship
 - **Claude Haiku 4.5** — Fast and lightweight for quick tasks
 
-### OpenAI (11 models)
+### OpenAI (6 models)
 
-- **GPT-5.2** — Latest GPT model, 400K context
-- **GPT-5.2 Codex** — Coding-optimized, 128K output, 400K context
-- **GPT-5.1** — Previous generation, 196K context
-- **GPT-5.1 Codex** — Coding-focused, 400K context
-- **GPT-5.1 Codex Max** — Extended reasoning Codex variant
-- **GPT-5** — 200K context
-- **GPT-5 Mini** — Fast and affordable, 128K context
-- **GPT-5 Codex** — Coding-focused, 200K context
-- **o4 Mini** — Fast reasoning model, 200K context
-- **GPT-4.1** — 1M context, large codebase support
-- **GPT-4.1 Mini** — 1M context, large codebase support
+- **GPT-5.2** — General-purpose GPT model, 400K context
+- **GPT-5.2 Codex** — Coding-optimized, 400K context
+- **GPT-5 Mini** — Fast, cost-effective, 400K context
+- **GPT-5.1 Codex** — Reliable coding assistant, 400K context
+- **GPT-5.1 Codex Max** — Extended reasoning for hard problems, 400K context
+- **GPT-5 Codex** — Stable baseline Codex model, 400K context
 
 ### Google (4 models)
 
@@ -94,6 +94,14 @@ These are our top picks, balancing capability, speed, and cost:
 
 - **MiniMax M2.5** — Strong reasoning at competitive pricing, 200K context
 - **MiniMax M2.5 Highspeed** — Faster variant, optimized for speed
+
+## Third Party Subscriptions
+
+### ChatGPT Subscription (OAuth)
+
+Use your existing **ChatGPT Plus/Pro** subscription to access Codex models in AdaL — no API key needed. You’ll see this under `/model` → **Third Party Subscriptions**.
+
+→ **[Setup guide: ChatGPT Subscription](../03-features/chatgpt-subscription.md)**
 
 ## Local Models (Preview)
 
@@ -121,7 +129,6 @@ Reusing context (files, conversation history) costs **50-90% less** with cached 
 Handle large codebases with models supporting up to **1M tokens**:
 - Claude Sonnet 4.6 (1M) / Opus 4.6 (1M)
 - Gemini 3.1 Pro / 3 Pro / Flash / 2.5 Pro
-- GPT-4.1
 
 Perfect for reviewing entire repositories or understanding complex systems.
 

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.8.4] - 2026-02-27
+- Fixed GPT models crashing during long sessions
+- Improved context window utilization to enable longer conversations before compaction
+- Deprecated older OpenAI models (GPT-4.1, o4-mini, standard GPT-5/5.1) and prioritized Codex variants
+- Added GPT-5.2 Codex as a recommended model
+
 ## [0.8.3] - 2026-02-25
 - Added image generation tool via Google Gemini's Nano Banana
 - Supported using ChatGPT subscription in adal to use OpenAI models


### PR DESCRIPTION
## TL;DR
Update the docs model page to match the current `/model` UI and registry: OpenAI list/counts, GPT-5.2 restored, and ChatGPT Subscription shown under Third Party Subscriptions.

## Changes
- Align `/model` screenshot section with current UI structure (Providers vs Third Party Subscriptions)
- Update OpenAI model list/counts (includes GPT-5.2 again)
- Add a dedicated Third Party Subscriptions section + link to ChatGPT Subscription setup guide
- Update docs-site changelog for 0.8.4

## Files
- docs-site/docs/01-getting-started/models.md
- docs-site/docs/CHANGELOG.md

🌸 Generated with [AdaL](https://github.com/adal-cli/)