### PR TITLE
docs: update changelog for 0.8.5

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.8.5] - 2026-02-28
+- Fixed GPT models via ChatGPT subscription returning "Unsupported parameter" errors
+
 ## [0.8.4] - 2026-02-27
 - Fixed GPT models crashing during long sessions
 - Improved context window utilization to enable longer conversations before compaction


### PR DESCRIPTION
Update doc site changelog with 0.8.5 release notes.

🌸 Generated with [AdaL](https://github.com/adal-cli/)