### PR TITLE
docs: finalize v0.9.0 models and changelog updates

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: Models & Billing
-description: "AdaL supports 20+ AI models — Claude Sonnet/Opus, GPT-5, Gemini 3, MiniMax, and local models via Ollama. Switch models instantly. Pay-per-token with prompt caching for 50-90% savings."
+description: "AdaL supports 20+ AI models — Claude Sonnet/Opus, GPT-5, Gemini 3, Z.ai GLM, MiniMax, and local models via Ollama. Switch models instantly. Pay-per-token with prompt caching for 50-90% savings."
 ---
 
 # Models & Billing
@@ -14,37 +14,12 @@ AdaL gives you access to the best AI models from leading providers — all in on
 /model
 ```
 
-Select from frontier models optimized for engineering tasks:
+Use `/model` to browse four sections:
 
-```
-> Select Model
-
-Switch AI model for this project. 21 models available
-
-Recommended
-
-○ Claude Sonnet 4.6      Anthropic • 200K
-○ Claude Opus 4.6        Anthropic • 200K
-○ Gemini 3.1 Pro         Google • 1M
-○ Gemini 3 Flash         Google • 1M
-○ GPT-5.2 Codex          OpenAI • 400K
-○ MiniMax M2.5           MiniMax • 200K
-○ MiniMax M2.5 Highspeed MiniMax • 200K
-
-Providers
-
-○ Anthropic  7 models →
-○ OpenAI     6 models →
-○ Google     4 models →
-○ MiniMax    2 models →
-○ Ollama     2 models →
-
-Third Party Subscriptions
-
-○ ChatGPT Subscription  Connected →
-
-↑↓ navigate · Enter select/open · Press i for info · Esc exit
-```
+- **Recommended**: curated top picks for most workflows
+- **New**: recently added models
+- **Providers**: full model lists grouped by provider
+- **Third Party Subscriptions**: OAuth-based third-party model access, such as ChatGPT Subscription
 
 Your selection persists across future AdaL sessions in this project.
 
@@ -54,46 +29,56 @@ These are our top picks, balancing capability, speed, and cost:
 
 | Model | Provider | Context | Best For |
 |-------|----------|---------|----------|
-| **Claude Sonnet 4.6** | Anthropic | 200K | Daily coding, cost-effective reasoning |
-| **Claude Opus 4.6** | Anthropic | 200K | Complex reasoning, production-quality code |
-| **Gemini 3.1 Pro** | Google | 1M | Flagship reasoning, advanced agentic capabilities |
-| **Gemini 3 Flash** | Google | 1M | Ultra-fast responses, budget-friendly |
-| **GPT-5.2 Codex** | OpenAI | 400K | Coding-optimized, large codebase support |
-| **MiniMax M2.5** | MiniMax | 200K | Strong reasoning at competitive pricing |
-| **MiniMax M2.5 Highspeed** | MiniMax | 200K | Strong and fast |
+| **GPT-5.3 Codex** | OpenAI | 272K | Coding-optimized for long-horizon tasks (default, price baseline) |
+| **Claude Sonnet 4.6** | Anthropic | 200K | Daily coding (slightly more expensive) |
+| **Claude Opus 4.6** | Anthropic | 200K | Complex reasoning, production code (2x more expensive) |
+| **Gemini 3.1 Pro** | Google | 1M | Multi-modal reasoning, design tasks (slightly cheaper) |
+| **Gemini 3 Flash** | Google | 1M | Ultra-fast, simple tasks (4x in / 5x out cheaper) |
+| **GLM-5** | Zai | 200K | General coding and reasoning (2x in / 5x out cheaper) |
+| **GLM-4.7 FlashX** | Zai | 200K | Fast budget coding (29x in / 40x out cheaper) |
+| **MiniMax M2.5 Highspeed** | MiniMax | 200K | Balanced for speed and reasoning (7x in / 4x out cheaper) |
 
 ## All Models by Provider
 
 ### Anthropic (7 models)
 
-- **Claude Sonnet 4.6** — Default model, adaptive thinking, 200K context
-- **Claude Sonnet 4.6 (1M)** — Extended 1M context for large codebases
-- **Claude Opus 4.6** — Top-tier reasoning, 200K context
-- **Claude Opus 4.6 (1M)** — Extended 1M context variant
-- **Claude Sonnet 4.5** — Previous generation, solid all-rounder
-- **Claude Opus 4.5** — Previous generation flagship
-- **Claude Haiku 4.5** — Fast and lightweight for quick tasks
+- **Claude Sonnet 4.6**
+- **Claude Sonnet 4.6 (1M)**
+- **Claude Opus 4.6**
+- **Claude Opus 4.6 (1M)**
+- **Claude Sonnet 4.5**
+- **Claude Opus 4.5**
+- **Claude Haiku 4.5**
 
-### OpenAI (6 models)
+### OpenAI (7 models)
 
-- **GPT-5.2** — General-purpose GPT model, 400K context
-- **GPT-5.2 Codex** — Coding-optimized, 400K context
-- **GPT-5 Mini** — Fast, cost-effective, 400K context
-- **GPT-5.1 Codex** — Reliable coding assistant, 400K context
-- **GPT-5.1 Codex Max** — Extended reasoning for hard problems, 400K context
-- **GPT-5 Codex** — Stable baseline Codex model, 400K context
+- **GPT-5.3 Codex**
+- **GPT-5.2**
+- **GPT-5.2 Codex**
+- **GPT-5 Mini**
+- **GPT-5.1 Codex**
+- **GPT-5.1 Codex Max**
+- **GPT-5 Codex**
 
 ### Google (4 models)
 
-- **Gemini 3.1 Pro** — Latest flagship reasoning, 1M context, advanced agentic capabilities
-- **Gemini 3 Pro** — Previous flagship reasoning, 1M context, multimodal
-- **Gemini 3 Flash** — Ultra-fast, 1M context, best value
-- **Gemini 2.5 Pro** — Legacy generation, 1M context
+- **Gemini 3.1 Pro**
+- **Gemini 3 Pro**
+- **Gemini 3 Flash**
+- **Gemini 2.5 Pro**
+
+### Zai (5 models)
+
+- **GLM-5**
+- **GLM-4.7**
+- **GLM-4.7 FlashX**
+- **GLM-4.7 Flash**
+- **GLM-4.5 Flash**
 
 ### MiniMax (2 models)
 
-- **MiniMax M2.5** — Strong reasoning at competitive pricing, 200K context
-- **MiniMax M2.5 Highspeed** — Faster variant, optimized for speed
+- **MiniMax M2.5**
+- **MiniMax M2.5 Highspeed**
 
 ## Third Party Subscriptions
 

--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -50,8 +50,9 @@ These are our top picks, balancing capability, speed, and cost:
 - **Claude Opus 4.5**
 - **Claude Haiku 4.5**
 
-### OpenAI (7 models)
+### OpenAI (8 models)
 
+- **GPT-5.4**
 - **GPT-5.3 Codex**
 - **GPT-5.2**
 - **GPT-5.2 Codex**

--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -30,6 +30,7 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 | `/byoak`               | Bring your own API keys      |
 | `/skills`              | List loaded skills           |
 | `/plugin`              | Manage plugins/marketplaces  |
+| `/subagent`            | Configure subagents          |
 
 
 ## Tips

--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -22,11 +22,10 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 | `/stats`               | Show session statistics      |
 | `/mcp`                 | Manage MCP servers           |
 | `/bashes`              | List background processes    |
-| `/auth`                | Show auth status             |
 | `/logout`              | Sign out and exit            |
 | `/quit`                | Exit AdaL CLI                |
 | `/theme`               | Change theme                 |
-| `/about`               | Show version info            |
+| `/about`               | Show version and auth status |
 | `/bug [desc]`          | Report a bug                 |
 | `/byoak`               | Bring your own API keys      |
 | `/skills`              | List loaded skills           |

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,10 +8,10 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
-## [0.9.0] - 2026-03-04
+## [0.9.0] - 2026-03-05
 - Added subagent support to improve AdaL's efficiency and performance
 - Optimized prompt caching to make AdaL 2x cost-effective
-- Added GPT-5.3 Codex from OpenAI and set it as the current default model
+- Added GPT-5.3 Codex and GPT-5.4 from OpenAI and set GPT-5.3 Codex as the current default model
 - Added GLM-5, GLM-4.7 FlashX and 3 more models from Zai
 - Upgraded image generation to Nano Banana 2 and enabled image editing
 - Memory optimization improvements for smoother long sessions

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,23 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.9.0] - 2026-03-04
+- Added subagent support to improve AdaL's efficiency and performance
+- Optimized prompt caching to make AdaL 2x cost-effective
+- Added GPT-5.3 Codex from OpenAI and set it as the current default model
+- Added GLM-5, GLM-4.7 FlashX and 3 more models from Zai
+- Upgraded image generation to Nano Banana 2 and enabled image editing
+- Memory optimization improvements for smoother long sessions
+- Corrected the effective input context window for all OpenAI models from 400k to 272k
+- Bug fixes in Ollama local model support
+- Refined /model panel metadata, pricing display, and selector UX
+- Removed /auth and merged auth details into /about
+- Keyboard shortcuts now respond to both lowercase and uppercase keys
+- Slash autocomplete completes commands without auto-running, allowing arguments to be added before execution
+- Fixed and optimized scrollbar behavior
+- Added context percentage display in the footer
+- Fixed inaccurate line counts in “click to expand”
+
 ## [0.8.5] - 2026-02-28
 - Fixed GPT models via ChatGPT subscription returning "Unsupported parameter" errors
 


### PR DESCRIPTION
## Summary
- align models page with current supported provider model lists
- add GPT-5.4 to OpenAI model recommendations and update model count
- update 0.9.0 changelog date and model notes

## Testing
- docs-only changes (no runtime tests)

🌸 Generated with [AdaL](https://github.com/adal-cli/)