### PR TITLE
Add session sharing and persistent memory proposals

### DIFF
--- a/docs-site/docs/03-features/manage-conversations.md
+++ b/docs-site/docs/03-features/manage-conversations.md
@@ -83,4 +83,4 @@ Perfect for reviewing long sessions or documenting your workflow.
 - Session metadata (timestamps, message count)
 
 
-**Related:** [Slash Commands](./slash-commands.md) · [Keyboard Shortcuts](./keyboard-shortcuts.md)
+**Related:** [Slash Commands](./slash-commands.md) · [Keyboard Shortcuts](./keyboard-shortcuts.md) · [Session Sharing](./session-sharing.md) · [Persistent Memory](./persistent-memory.md)

--- a/docs-site/docs/03-features/persistent-memory.md
+++ b/docs-site/docs/03-features/persistent-memory.md
@@ -1,0 +1,381 @@
+---
+sidebar_position: 9
+title: Persistent Memory
+description: "Give AdaL long-term memory that persists across sessions. Project context, learned patterns, and coding preferences stored as plain files — version-controlled, shareable, and human-editable."
+---
+
+# Persistent Memory
+
+Give AdaL memory that lasts. Instead of re-explaining your project, conventions, and preferences every session, AdaL remembers — and gets better over time.
+
+:::info Proposed Feature
+This is a proposed feature for AdaL CLI. Inspired by memory architectures in tools like [Letta](https://github.com/letta-ai/letta-code) (formerly MemGPT). If you'd like to see this implemented, upvote or comment on the [GitHub issue](https://github.com/SylphAI-Inc/adal-cli/issues).
+:::
+
+## The Problem
+
+Every new AdaL session starts from scratch. You end up repeating yourself:
+
+```
+> We use Bun, not npm. Always use `bun run` and `bun install`.
+> Our API follows REST conventions with snake_case.
+> Tests go in __tests__/ next to the source file.
+> We use Tailwind, don't write raw CSS.
+```
+
+`AGENTS.md` partially solves this — but it's all-or-nothing (loaded every session regardless of relevance) and doesn't grow or learn from your interactions.
+
+## The Solution: Memory as Files
+
+Persistent memory is stored as **plain markdown files** in your project and home directory. AdaL reads them at the start of each session, learns from interactions, and writes new knowledge back.
+
+```
+.adal/memory/                    # Project memory (git-tracked, shared with team)
+├── system/                      # Always loaded into context
+│   ├── project/
+│   │   ├── overview.md          # What this project is
+│   │   ├── architecture.md      # System design
+│   │   ├── conventions.md       # Code style and patterns
+│   │   └── tooling.md           # Build tools, test framework, linter
+│   └── team/
+│       └── workflow.md          # PR process, branch naming, deploy steps
+├── reference/                   # Loaded on-demand when relevant
+│   ├── api-patterns.md          # Common API patterns in this codebase
+│   ├── gotchas.md               # Known footguns and workarounds
+│   └── solved/
+│       ├── auth-timeout.md      # How we fixed the auth timeout
+│       └── migration-v2.md      # Notes from the v2 migration
+└── .gitignore                   # Ignore personal preferences
+
+~/.adal/memory/                  # Personal memory (follows you everywhere)
+├── system/
+│   ├── identity.md              # Who you are, your role
+│   └── preferences/
+│       ├── coding-style.md      # Tabs vs spaces, naming conventions
+│       ├── communication.md     # Verbosity, explanation depth
+│       └── tools.md             # Preferred tools and frameworks
+└── reference/
+    └── learnings.md             # Things AdaL learned about you over time
+```
+
+### Why Files?
+
+| Approach | AdaL Memory | Database | Vector Store |
+|----------|-------------|----------|-------------|
+| **Inspect** | Open in any editor | Need a DB client | Need an API |
+| **Edit** | Edit like any file | Write SQL/queries | Re-embed |
+| **Version** | `git log` | Needs migration | No history |
+| **Share** | `git push` | Export/import | Platform-locked |
+| **Review** | PR review | Hard to diff | Opaque |
+| **Backup** | Already in git | Separate backup | Separate backup |
+
+## Memory Tiers
+
+Inspired by how operating systems manage memory — frequently needed data stays close, everything else is a search away.
+
+### Tier 1: System Memory (Always In Context)
+
+Files under `system/` are injected into AdaL's system prompt every session. Keep these **small, high-signal, and current**.
+
+```
+.adal/memory/system/
+```
+
+- Loaded automatically at session start
+- Counts against your context window
+- Target: **~40 lines max per file**, 10-15 files total
+- Think of it as RAM — fast access, limited space
+
+**What belongs here:**
+- Project overview and architecture
+- Active coding conventions
+- Current sprint/focus areas
+- Team workflow (branch naming, PR process)
+
+**What doesn't belong here:**
+- Historical debugging notes (move to `reference/`)
+- Rarely-used API docs (move to `reference/`)
+- Personal preferences on a team project (use `~/.adal/memory/`)
+
+### Tier 2: Reference Memory (Loaded On Demand)
+
+Files under `reference/` are **not** loaded into context by default. AdaL searches them when your task matches.
+
+```
+.adal/memory/reference/
+```
+
+- Searchable by the agent when relevant
+- Doesn't consume context window until needed
+- No size limit — store as much as you want
+- Think of it as disk — large capacity, accessed when needed
+
+**What belongs here:**
+- Solved problem write-ups
+- API reference notes
+- Debugging playbooks
+- Migration guides
+- Historical context
+
+### Tier 3: Recall (Conversation History)
+
+AdaL already persists conversations via `/resume`. Persistent memory extends this with **cross-session search** — find what you discussed last week without knowing which session it was.
+
+```bash
+# Search across all past sessions
+adal memory search "how did we fix the rate limiter"
+# → Found in session abc123 (2026-02-28):
+#   "The rate limiter was hitting Redis timeouts because..."
+```
+
+## Proposed Commands
+
+### Initialize Memory
+
+```bash
+adal memory init
+```
+
+Bootstraps the `.adal/memory/` directory by analyzing your codebase:
+
+```
+> Scanning codebase...
+> Detected: TypeScript, Bun, React, Tailwind, PostgreSQL
+> Detected: monorepo with apps/ and packages/
+> Generated 18 memory files in .adal/memory/system/
+
+project/overview.md       — SaaS billing platform, monorepo
+project/architecture.md   — apps/web (Next.js), apps/api (Hono), packages/db
+project/conventions.md    — snake_case APIs, PascalCase components, Zod schemas
+project/tooling.md        — Bun, Biome, Vitest, Drizzle ORM
+team/workflow.md          — trunk-based, squash merge, deploy on merge to main
+```
+
+### View Memory
+
+```bash
+# Show memory tree
+adal memory status
+
+# Show what's loaded in the current session
+adal memory active
+```
+
+**In-session slash command:**
+
+```
+/memory              # Browse memory files
+/memory status       # Show loaded vs available
+/memory search <q>   # Search across all memory tiers
+```
+
+### Edit Memory
+
+Memory files are plain markdown — edit them with any text editor, IDE, or let AdaL update them during a session.
+
+```bash
+# Open memory directory
+code .adal/memory/
+
+# Or let AdaL learn from the current session
+/memory learn
+# → AdaL reviews the session and updates relevant memory files
+```
+
+### Teach AdaL
+
+Explicitly tell AdaL to remember something:
+
+```
+> Remember: we always use `bun test --coverage` before PRs
+
+AdaL: ✓ Added to .adal/memory/system/project/tooling.md:
+  "Run `bun test --coverage` before opening PRs"
+```
+
+Or correct the agent and it learns:
+
+```
+> No, we use snake_case for API responses, not camelCase
+
+AdaL: ✓ Updated .adal/memory/system/project/conventions.md:
+  API responses: snake_case (not camelCase)
+```
+
+### Sync Across Devices
+
+**Project memory** syncs automatically via git — it's just files in your repo.
+
+**Personal memory** (`~/.adal/memory/`) can sync via:
+
+```bash
+# Initialize personal memory as a git repo
+adal memory sync init
+
+# Push to your private remote
+adal memory sync push
+
+# Pull on another device
+adal memory sync pull
+```
+
+Under the hood, this is a standard git repo at `~/.adal/memory/` with a remote you configure once.
+
+## Memory File Format
+
+Each memory file uses YAML frontmatter for metadata, followed by markdown content:
+
+```markdown
+---
+description: Project coding conventions and style guide
+limit: 5000
+updated: 2026-03-05
+source: learned
+---
+
+# Coding Conventions
+
+## Naming
+- **API responses**: snake_case
+- **React components**: PascalCase
+- **Database columns**: snake_case
+- **Environment variables**: SCREAMING_SNAKE_CASE
+
+## File Structure
+- Tests: `__tests__/` directory next to source
+- Components: one component per file
+- Hooks: `use` prefix, in `hooks/` directory
+
+## Imports
+- Absolute imports via `@/` alias
+- Group: external → internal → relative → types
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `description` | Yes | What this memory block contains (used for search) |
+| `limit` | Yes | Max character count for this block |
+| `updated` | No | Last modification date |
+| `source` | No | How this was created: `manual`, `learned`, `init` |
+| `read_only` | No | If `true`, the agent cannot modify this file |
+| `tags` | No | Searchable tags for reference memory |
+
+## How It Works With Existing Features
+
+### AGENTS.md Compatibility
+
+`AGENTS.md` and persistent memory **complement each other**:
+
+| Feature | AGENTS.md | Persistent Memory |
+|---------|-----------|-------------------|
+| **Loaded** | Always, fully | System: always / Reference: on-demand |
+| **Editable by agent** | No | Yes (agent learns and updates) |
+| **Scope** | Repository instructions | Broader context + learned knowledge |
+| **Format** | Single file | Hierarchical directory |
+| **Best for** | Static rules ("always do X") | Evolving knowledge ("we learned Y") |
+
+Use `AGENTS.md` for hard rules. Use memory for everything else.
+
+### Skills Integration
+
+Skills can **read and write** memory files. A skill for PR reviews could check `project/conventions.md` to enforce your team's style. A debugging skill could write findings to `reference/solved/`.
+
+```yaml
+# SKILL.md
+name: pr-review
+description: Review PRs against team conventions
+memoryBlocks: [project/conventions, team/workflow]
+```
+
+### Session Resume + Memory
+
+When you `/resume` a session, AdaL loads both the conversation history **and** any memory that was updated during that session. If memory was modified since the session ended (by another team member or on another device), the agent sees the latest version.
+
+## Team Workflows
+
+### Onboarding New Developers
+
+Project memory doubles as living documentation. When a new developer joins:
+
+1. They clone the repo (which includes `.adal/memory/`)
+2. AdaL immediately knows the project's architecture, conventions, and tooling
+3. No onboarding prompt needed — just start asking questions
+
+```
+# New developer's first session
+> How is the project structured?
+
+AdaL: Based on the project memory, this is a monorepo with...
+(reads from .adal/memory/system/project/architecture.md)
+```
+
+### Shared Learnings via Pull Requests
+
+When AdaL learns something new, it writes to memory files. These show up in your PR diff:
+
+```diff
+# .adal/memory/reference/solved/rate-limiter-fix.md (new file)
++ ---
++ description: Rate limiter Redis timeout fix
++ limit: 3000
++ source: learned
++ tags: [redis, rate-limiting, performance]
++ ---
++
++ # Rate Limiter Redis Timeout
++
++ ## Problem
++ Rate limiter was timing out under load because...
++
++ ## Solution
++ Switched from per-request Redis calls to a sliding window...
+```
+
+Your team reviews these memory updates just like code changes.
+
+### Protected Memory
+
+Mark files as `read_only` to prevent the agent from modifying critical project rules:
+
+```yaml
+---
+description: Immutable deployment process
+limit: 3000
+read_only: true
+---
+```
+
+Only humans can edit `read_only` memory files. The agent can read them but never overwrite them.
+
+## Privacy & Security
+
+| Concern | How It's Handled |
+|---------|-----------------|
+| **Project secrets** | `.adal/memory/.gitignore` excludes sensitive files |
+| **Personal data** | `~/.adal/memory/` stays local (you control syncing) |
+| **Team visibility** | `.adal/memory/` is in the repo — everything is reviewable |
+| **Agent modifications** | All changes are git-tracked — full audit trail |
+| **Accidental overwrites** | `read_only` frontmatter prevents agent writes |
+
+## Getting Started
+
+```bash
+# 1. Initialize project memory
+adal memory init
+
+# 2. Review generated files
+code .adal/memory/
+
+# 3. Commit to git
+git add .adal/memory/
+git commit -m "feat: initialize AdaL project memory"
+
+# 4. Start a session — AdaL now remembers
+adal
+```
+
+That's it. AdaL loads project memory automatically on every session. It grows smarter as you work — learning conventions, documenting solutions, and sharing knowledge with your team through git.
+
+**Related:** [Skills & Plugins](./plugins-and-skills.md) · [Manage & Resume Sessions](./manage-conversations.md) · [Session Sharing](./session-sharing.md)

--- a/docs-site/docs/03-features/plugins-and-skills.md
+++ b/docs-site/docs/03-features/plugins-and-skills.md
@@ -261,4 +261,4 @@ When skills have the same name, first-loaded wins:
 
 Use **Skills** for domain expertise and workflows, **MCP** for real-time tool access, and **AGENTS.md** for project-wide context. They complement each other.
 
-**Related:** [Slash Commands](./slash-commands.md) · [MCP Servers](./mcp-support-proposed.md) · [Workflows & Examples](../01-getting-started/workflows-and-examples.md)
+**Related:** [Slash Commands](./slash-commands.md) · [MCP Servers](./mcp-support-proposed.md) · [Workflows & Examples](../01-getting-started/workflows-and-examples.md) · [Persistent Memory](./persistent-memory.md)

--- a/docs-site/docs/03-features/session-sharing.md
+++ b/docs-site/docs/03-features/session-sharing.md
@@ -1,0 +1,302 @@
+---
+sidebar_position: 8
+title: Session Sharing
+description: "Export, share, and import AdaL coding sessions. Share context with teammates, hand off work across devices, and build on each other's conversations."
+---
+
+# Session Sharing
+
+Export conversations, share them with teammates, and import sessions to continue where someone else left off.
+
+:::info Proposed Feature
+This is a proposed feature for AdaL CLI. If you'd like to see this implemented, upvote or comment on the [GitHub issue](https://github.com/SylphAI-Inc/adal-cli/issues).
+:::
+
+## Why Share Sessions?
+
+| Use Case | Problem | Solution |
+|----------|---------|----------|
+| **Team handoffs** | "I debugged this for an hour, now you need to continue" | Export your session and hand it off |
+| **Cross-device** | Started on your laptop, need to finish on desktop | Export → transfer → import |
+| **Code reviews** | "How did the AI arrive at this solution?" | Share the full reasoning chain |
+| **Knowledge base** | Solved a tricky problem? Others can learn from it | Archive sessions as team reference |
+| **Bug reports** | Reproducing an issue needs full context | Share the exact session that triggered it |
+
+## Proposed Commands
+
+### Export a Session
+
+```bash
+adal session export [session-id] [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--format` | Output format: `md`, `json`, `html` | `md` |
+| `--output` | Output file path | `./adal-session-<id>.<ext>` |
+| `--redact` | Strip API keys, file paths, secrets | `true` |
+| `--include-tools` | Include tool calls and outputs | `true` |
+| `--include-thinking` | Include model thinking/reasoning | `false` |
+| `--compact` | Omit system prompts and metadata | `false` |
+
+**Examples:**
+
+```bash
+# Export current session as markdown
+adal session export
+
+# Export a specific session as JSON
+adal session export abc123 --format json
+
+# Export without tool call details (cleaner for sharing)
+adal session export --include-tools false
+
+# Export with full reasoning chain
+adal session export --include-thinking --format html
+```
+
+### Share a Session
+
+```bash
+adal session share [session-id] [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--expires` | Link expiration | `7d` |
+| `--access` | `read-only` or `forkable` | `read-only` |
+| `--gist` | Upload as GitHub Gist | `false` |
+
+**Examples:**
+
+```bash
+# Share via a temporary link
+adal session share
+# → https://share.sylph.ai/s/x7k9m2 (expires in 7 days)
+
+# Share as a GitHub Gist
+adal session share --gist
+# → https://gist.github.com/user/abc123
+
+# Allow others to fork and continue the session
+adal session share --access forkable
+```
+
+### Import a Session
+
+```bash
+adal session import <source> [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--mode` | `continue` (append) or `reference` (read-only context) | `reference` |
+| `--merge-memory` | Merge the imported session's learned context | `false` |
+
+**Examples:**
+
+```bash
+# Import from a file
+adal session import ./adal-session-abc123.md
+
+# Import from a shared link
+adal session import https://share.sylph.ai/s/x7k9m2
+
+# Import and continue the conversation
+adal session import ./handoff.json --mode continue
+
+# Import as read-only context for a new session
+adal session import ./teammate-debug.md --mode reference
+```
+
+## Export Formats
+
+### Markdown (default)
+
+Human-readable, works everywhere. Ideal for documentation and code reviews.
+
+````markdown
+# AdaL Session Export
+- **Session ID:** abc123
+- **Date:** 2026-03-05
+- **Model:** Claude Sonnet 4.6
+- **Messages:** 24
+- **Duration:** 45 minutes
+- **Project:** /Users/dev/myapp
+
+---
+
+## User
+Fix the authentication timeout in `src/auth/login.ts`
+
+## AdaL
+I'll investigate the authentication timeout issue...
+
+### Tool: Read File
+`src/auth/login.ts`
+
+### Tool: Edit File
+```diff
+- const TIMEOUT = 5000;
++ const TIMEOUT = 30000;
+```
+
+The timeout was set to 5 seconds...
+
+---
+
+## User
+Now add retry logic
+
+## AdaL
+...
+````
+
+### JSON
+
+Machine-readable, preserves all metadata. Ideal for programmatic use and re-import.
+
+```json
+{
+  "version": "1.0",
+  "session_id": "abc123",
+  "exported_at": "2026-03-05T14:30:00Z",
+  "metadata": {
+    "model": "claude-sonnet-4-6",
+    "project": "/Users/dev/myapp",
+    "message_count": 24,
+    "token_usage": { "input": 45000, "output": 12000 },
+    "duration_seconds": 2700
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Fix the authentication timeout",
+      "timestamp": "2026-03-05T14:00:00Z"
+    },
+    {
+      "role": "assistant",
+      "content": "I'll investigate...",
+      "tool_calls": [
+        {
+          "tool": "read_file",
+          "input": { "path": "src/auth/login.ts" },
+          "output": "..."
+        }
+      ],
+      "timestamp": "2026-03-05T14:00:05Z"
+    }
+  ]
+}
+```
+
+### HTML
+
+Rich, styled view for the browser. Uses the same format as the `/stats` history view but is portable as a standalone file.
+
+## Privacy & Redaction
+
+Session exports automatically redact sensitive content before sharing:
+
+| Content | Action | Example |
+|---------|--------|---------|
+| API keys & tokens | Replaced with `[REDACTED]` | `ghp_xxxx` → `[REDACTED]` |
+| Absolute file paths | Shortened to relative | `/Users/john/app/src` → `./src` |
+| Environment variables | Values masked | `DB_PASS=secret` → `DB_PASS=[REDACTED]` |
+| `.env` file contents | Fully masked | Entire content replaced |
+| IP addresses & URLs | Optionally masked | `--redact-urls` flag |
+
+**Disable redaction** (for personal exports only):
+
+```bash
+adal session export --redact false
+```
+
+:::caution
+Always review exported sessions before sharing externally. Automated redaction catches common patterns but cannot guarantee complete removal of sensitive data.
+:::
+
+## Workflow Examples
+
+### Team Handoff
+
+Developer A hits a wall and hands off to Developer B:
+
+```bash
+# Developer A: export with full context
+adal session export --format json --output handoff.json
+
+# Share via your team's preferred method
+# Slack, email, shared drive, git...
+
+# Developer B: import and continue
+adal session import ./handoff.json --mode continue
+> Resuming session from Developer A (24 messages loaded)
+> Last context: fixing auth timeout in src/auth/login.ts
+```
+
+### Cross-Device Resume
+
+Started debugging on your laptop, need to finish on your desktop:
+
+```bash
+# On laptop
+adal session share --expires 1d
+# → https://share.sylph.ai/s/x7k9m2
+
+# On desktop
+adal session import https://share.sylph.ai/s/x7k9m2 --mode continue
+```
+
+### Building a Team Knowledge Base
+
+Archive solved problems so the team can reference them:
+
+```bash
+# Export the session that solved a tricky bug
+adal session export --format md --output docs/solved/auth-timeout-fix.md
+
+# Future sessions can reference it
+adal session import docs/solved/auth-timeout-fix.md --mode reference
+> How did we fix the auth timeout last time? ^
+```
+
+### Slash Command Integration
+
+Session sharing integrates with existing slash commands:
+
+```
+/stats           → View current session, see export options
+/resume          → Browse sessions, export any of them
+/share           → Quick share current session (shortcut for `adal session share`)
+```
+
+## Data Format Specification
+
+### Session File Structure
+
+Exported sessions follow a standard schema that any tool can parse:
+
+```
+adal-session-<id>/
+├── session.json          # Metadata and messages
+├── context/              # Referenced files (snapshots)
+│   ├── src/auth/login.ts
+│   └── package.json
+└── README.md             # Human-readable summary
+```
+
+The `context/` directory includes **snapshots** of files that were read or edited during the session, so the imported session has full context even in a different repository.
+
+## Implementation Notes
+
+This feature builds on AdaL's existing session infrastructure:
+
+- **`/stats`** already tracks session ID, token usage, and message counts
+- **`/resume`** already serializes/deserializes session state
+- **HTML history view** already generates styled conversation exports
+- Session metadata is already persisted for resume functionality
+
+The proposed commands extend these capabilities with portable export formats, privacy controls, and import/merge logic.
+
+**Related:** [Manage & Resume Sessions](./manage-conversations.md) · [Slash Commands](./slash-commands.md) · [Persistent Memory](./persistent-memory.md)

--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -31,6 +31,8 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 | `/skills`              | List loaded skills           |
 | `/plugin`              | Manage plugins/marketplaces  |
 | `/subagent`            | Configure subagents          |
+| `/memory`              | Browse and manage memory     |
+| `/share`               | Share current session        |
 
 
 ## Tips
@@ -39,4 +41,4 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 - Run `/init` to generate AGENTS.md so that AdaL can understand your codebase better.
 - Use `/compact` after a milestone is achieved to save context and stay focused, or switch to a larger-context model via `/model` when needed.
 
-**Related:** [MCP](./mcp-support-proposed.md) · [BYOAK](./bring-your-own-api-key.md)
+**Related:** [MCP](./mcp-support-proposed.md) · [BYOAK](./bring-your-own-api-key.md) · [Session Sharing](./session-sharing.md) · [Persistent Memory](./persistent-memory.md)


### PR DESCRIPTION
- Add session-sharing.md: export, share, and import session proposals with CLI interface, format specs, privacy/redaction, and workflow examples
- Add persistent-memory.md: tiered memory system proposal with system/reference/recall tiers, file format spec, and team workflows
- Update slash-commands.md: add /memory and /share to command table
- Update manage-conversations.md: add cross-links to new pages
- Update plugins-and-skills.md: add cross-link to persistent memory