### PR TITLE
docs: de-emphasize AdaL Web in getting started docs

### DIFF
--- a/docs-site/docs/01-getting-started/adal-web.md
+++ b/docs-site/docs/01-getting-started/adal-web.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 5
-title: AdaL Web — Browser UI
-description: "AdaL Web is a browser-based AI coding agent interface. Same capabilities as AdaL CLI — file editing, web search, code generation — with a graphical UI. Launch with adal --web."
+title: AdaL Web (Preview)
+description: "AdaL Web (Preview) is a browser-based AI coding agent interface. Core capabilities are available today, with full feature parity planned. Launch with adal --web."
 ---
 
 # AdaL Web (Preview)
 
-AdaL Web is a browser-based interface for AdaL, launched from the same CLI you already use.
+AdaL Web is a browser-based interface for AdaL, launched from the same CLI package you already use.
 
 ## Launch
 
@@ -24,7 +24,8 @@ AdaL Web shares the same agent engine and backend as AdaL CLI. Core capabilities
 
 ### Available Now
 
-- Conduct tasks with all tools, such as read, edit, web search, bash tools.
+- Conduct tasks with all tools, such as read, edit, web search, and bash tools
+- Subagent availability
 - Toggles for model selection, plan mode, auto-approve edits
 - Image upload and select project files as context from the sidebar
 - AGENTS.md creation from the sidebar

--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -20,21 +20,9 @@ npm install -g @sylphai/adal-cli
 
 Open any terminal (VS Code, iTerm, macOS Terminal (macOS 26+ supports AdaL themes better), PowerShell, Linux shell, etc.), `cd` to your working directory, and run:
 
-### AdaL CLI (default)
-
 ```bash
 adal
 ```
-
-### AdaL Web (Preview) — New ✨
-
-```bash
-adal --web
-```
-
-This automatically opens AdaL in your default browser. Same agent capabilities as AdaL CLI — file editing, web search, code generation, etc — with a graphical interface. 
-
-→ **[Learn more about AdaL Web](./adal-web.md)**
 
 First run opens browser for authentication, then you're ready.
 
@@ -116,7 +104,6 @@ If colors appear off in the macOS Terminal app, upgrade to macOS 26+ for full tr
 
 ## What's Next?
 
-- **[AdaL Web →](./adal-web.md)** - Browser-based interface
 - **[Workflows & Examples →](./workflows-and-examples.md)** - Practical development patterns
 - **[Slash Commands →](../03-features/slash-commands.md)** - All commands
 - **[Keyboard Shortcuts →](../03-features/keyboard-shortcuts.md)** - Full reference

--- a/docs-site/docs/01-getting-started/welcome.md
+++ b/docs-site/docs/01-getting-started/welcome.md
@@ -16,7 +16,7 @@ I was created by [SylphAI](https://sylph.ai) and named after Ada Lovelace, the w
 
 Built by a 10x productive team with best engineering practices baked in. I leverage any model — text, image, reasoning — to 10x your work across UI/UX design, project planning, implementation, deployment, and GTM. I enable developers to iterate at the speed of thought. Follow me on [GitHub](https://github.com/adal-cli).
 
-I am available as a terminal CLI — **AdaL CLI** (`adal`) or browser UI — **AdaL Web** (`adal --web`) — both launched from your terminal. Works with Claude, GPT, Gemini, MiniMax, and local models via Ollama.
+I am available as a terminal CLI — **AdaL CLI** (`adal`) — launched from your terminal. Works with Claude, GPT, Gemini, GLM, MiniMax, and local models.
 
 **Key capabilities:** [Code & debug](/getting-started/workflows-and-examples) · [MCP servers](/features/mcp-support-proposed) · [Skills & plugins](/features/plugins-and-skills) · [Image generation](/features/image-generation) · [Web search](/features/web-search) · [Local models](/features/local-models) · [AGENTS.md project context](/getting-started/workflows-and-examples#set-up-project-context)
 


### PR DESCRIPTION
## Summary
- remove direct AdaL Web mentions from Welcome page
- remove AdaL Web launch/link from Quickstart
- mark AdaL Web page metadata as Preview

## Testing
- docs-only changes; no runtime tests required

🌸 Generated with [AdaL](https://github.com/adal-cli/)