### PR TITLE
docs: align 0.9.4 docs with worktree rename and changelog

### DIFF
--- a/docs-site/docs/01-getting-started/quickstart.md
+++ b/docs-site/docs/01-getting-started/quickstart.md
@@ -65,16 +65,16 @@ First run opens browser for authentication, then you're ready.
 | `@` | Target specific file as context | `@src/api.ts add validation` |
 | `!` | Run shell command | `!git status` |
 
-## Workspace Management
+## Worktree Management
 
 Work on multiple branches in parallel:
 
 | Command | What it does |
 |---------|--------------|
-| `adal workspace create -b <name>` | Create new workspace from main |
-| `adal workspace create -b <name> <start-point>` | Create from specific branch |
-| `adal workspace list` | List all workspaces |
-| `adal workspace delete <name>` | Delete workspace |
+| `adal worktree create -b <name>` | Create new worktree from main |
+| `adal worktree create -b <name> <start-point>` | Create from specific branch |
+| `adal worktree list` | List all worktrees |
+| `adal worktree delete <name>` | Delete worktree |
 ## Terminal Setup
 
 **Recommended terminals:**

--- a/docs-site/docs/01-getting-started/workflows-and-examples.md
+++ b/docs-site/docs/01-getting-started/workflows-and-examples.md
@@ -175,35 +175,35 @@ Keep your session focused and clean:
 
 ## Work on Multiple Branches
 
-Create isolated workspaces to work on different features simultaneously without switching branches:
+Create isolated worktrees to work on different features simultaneously without switching branches:
 
 ```bash
-# Create workspace from main (default)
-adal workspace create -b feature-auth
+# Create worktree from main (default)
+adal worktree create -b feature-auth
 
-# Create workspace from a specific branch
-adal workspace create -b feature-auth develop
+# Create worktree from a specific branch
+adal worktree create -b feature-auth develop
 
-# Create workspace from remote branch
-adal workspace create -b hotfix origin/main
+# Create worktree from remote branch
+adal worktree create -b hotfix origin/main
 
-# Start working in workspace
-cd .adal_workspace/workspace-feature-auth && adal
+# Start working in worktree
+cd .adal_worktree/worktree-feature-auth && adal
 
-# In another terminal, create second workspace
-adal workspace create -b feature-payments
-cd .adal_workspace/workspace-feature-payments && adal
+# In another terminal, create second worktree
+adal worktree create -b feature-payments
+cd .adal_worktree/worktree-feature-payments && adal
 
-# Check workspaces
-adal workspace list
+# Check worktrees
+adal worktree list
 
 # Delete when done (use -f to force delete with unsaved changes)
-adal workspace delete feature-auth
+adal worktree delete feature-auth
 ```
 
-**Environment files are copied automatically.** When you create a workspace, AdaL copies your `.env` files so API keys and secrets are available without manual setup.
+**Environment files are copied automatically.** When you create a worktree, AdaL copies your `.env` files so API keys and secrets are available without manual setup.
 
-Customize what gets copied with `.adal_workspace_config` in your project root:
+Customize what gets copied with `.adal_worktree_config` in your project root:
 
 ```ini
 [copy]
@@ -211,7 +211,7 @@ include = .env
 include = config/*.json
 ```
 
-Add any files your workspaces need — database configs, local settings, credential files — and they'll be included automatically on `workspace create`.
+Add any files your worktrees need — database configs, local settings, credential files — and they'll be included automatically on `worktree create`.
 
 
 ## Quick Reference

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.9.4] - 2026-03-11
+- Improved image generation reliability
+- Fixed incorrect mapping of queued @file references to images
+- Corrected hidden-line counts in diff view
+- Resolved a plugin install issue affecting some marketplace sources
+- Consolidated `adal --help` information
+- Renamed `adal workspace` to `adal worktree` and simplified its usage
+- Added `--model` support for headless mode to specify models
+- Added a clear "Text-only" capability indicator in model selection for non-vision models
+- Minor UI improvements for assistant messages
+
 ## [0.9.3] - 2026-03-07
 - Terminal tab title now shows AdaL
 - Bug fix in edit file path resolution


### PR DESCRIPTION
## Summary
- update Quickstart commands from `adal workspace` to `adal worktree`
- update Workflows examples and naming from workspace to worktree
- include 0.9.4 changelog notes in docs changelog

## Testing
- docs-only changes; no runtime tests required

🌸 Generated with [AdaL](https://github.com/adal-cli/)