### PR TITLE
docs: add 0.9.6 changelog entry

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.9.6] - 2026-03-14
+- Fixed MCP servers incorrectly showing as "not ready" after successful authentication
+
 ## [0.9.5] - 2026-03-11
 - Improved reliability for GLM requests
 


### PR DESCRIPTION
## Summary
- add 0.9.6 changelog note for MCP server readiness status fix after authentication

## Testing
- docs-only change; no runtime tests required

🌸 Generated with [AdaL](https://github.com/adal-cli/)