### PR TITLE
docs: update v0.9.7 model docs and changelog

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -67,8 +67,9 @@ These are our top picks, balancing capability, speed, and cost:
 - **Gemini 3 Flash**
 - **Gemini 2.5 Pro**
 
-### Zai (5 models)
+### Zai (6 models)
 
+- **GLM-5-Turbo**
 - **GLM-5**
 - **GLM-4.7**
 - **GLM-4.7 FlashX**

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.9.7] - 2026-03-16
+- Added GLM-5-Turbo from Z.ai
+- Reduced TimeoutError for Claude Opus models to allow long responses to pass
+
 ## [0.9.6] - 2026-03-14
 - Fixed MCP servers incorrectly showing as "not ready" after successful authentication
 


### PR DESCRIPTION
## Summary
- add GLM-5-Turbo to the Z.ai model list in Models & Billing
- update Z.ai model count from 5 to 6
- include v0.9.7 changelog notes

## Testing
- docs-only changes; no runtime tests required

🌸 Generated with [AdaL](https://github.com/adal-cli/)