### PR TITLE
docs: add 0.9.8 changelog entry

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.9.8] - 2026-03-17
+- Improved Claude streaming reliability with fewer timeout errors
+- Improved error messages for rate limits for clarity
+
 ## [0.9.7] - 2026-03-16
 - Added GLM-5-Turbo from Z.ai
 - Reduced TimeoutError for Claude Opus models to allow long responses to pass


### PR DESCRIPTION
## Summary
- add 0.9.8 changelog notes for Claude streaming reliability improvements
- add 0.9.8 changelog note for clearer rate limit error messages

## Testing
- docs-only change; no runtime tests required

🌸 Generated with [AdaL](https://github.com/adal-cli/)