### PR TITLE
docs: align 0.9.9 models and slash commands docs

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -76,8 +76,10 @@ These are our top picks, balancing capability, speed, and cost:
 - **GLM-4.7 Flash**
 - **GLM-4.5 Flash**
 
-### MiniMax (2 models)
+### MiniMax (4 models)
 
+- **MiniMax M2.7**
+- **MiniMax M2.7 Highspeed**
 - **MiniMax M2.5**
 - **MiniMax M2.5 Highspeed**
 

--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -31,6 +31,7 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 | `/skills`              | List loaded skills           |
 | `/plugin`              | Manage plugins/marketplaces  |
 | `/subagent`            | Configure subagents          |
+| `/permissions`         | Configure approvals (includes YOLO mode) |
 
 
 ## Tips

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [0.9.9] - 2026-03-18
+- Added MiniMax M2.7 and M2.7 Highspeed models
+- Added YOLO mode to auto-approve all tools and bash commands (/permissions)
+
 ## [0.9.8] - 2026-03-17
 - Improved Claude streaming reliability with fewer timeout errors
 - Improved error messages for rate limits for clarity


### PR DESCRIPTION
## Summary
- add MiniMax M2.7 and M2.7 Highspeed to Models page
- add `/permissions` command to Slash Commands quick reference
- include 0.9.9 changelog updates

## Testing
- docs-only changes; no runtime tests required

🌸 Generated with [AdaL](https://github.com/adal-cli/)