### PR TITLE
docs(changelog): add 1.0.1 release notes

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [1.0.1] - 2026-03-31
+
+- Optimized the running memory of the AdaL session process
+- Improved Claude model requests stability
+- Added worktree info in exit UX if applicable
+
 ## [1.0.0] - 2026-03-27
 - Introduced Deep Research, a dedicated mode for investigating complex tasks and delivering structured reports (Tab to toggle)
 - Added Linux ARM64 support


### PR DESCRIPTION
## Summary
Add the 1.0.1 changelog entry.

## Changes
- Added `## [1.0.1] - 2026-03-31`
- Included 3 highlights:
  - optimized AdaL session process memory usage
  - improved Claude request stability
  - added worktree info in exit UX when applicable

🌸 Generated with [AdaL](https://github.com/adal-cli/)