### PR TITLE
docs: document /permissions and fix Tab/Shift+Tab shortcuts

### DIFF
--- a/docs-site/docs/03-features/keyboard-shortcuts.md
+++ b/docs-site/docs/03-features/keyboard-shortcuts.md
@@ -37,6 +37,7 @@ Quick reference for all keyboard shortcuts in AdaL CLI.
 
 | Shortcut    | Action                                    |
 | ----------- | ----------------------------------------- |
+| `Tab`       | Cycle conversation mode (Normal/Plan/Deep Research) |
 | `Shift+Tab` | Toggle auto-accept edit mode              |
 | `Ctrl+P`    | Toggle plan mode                          |
 | `Ctrl+R`    | Expand/collapse thinking content          |
@@ -44,6 +45,11 @@ Quick reference for all keyboard shortcuts in AdaL CLI.
 
 
 ## Mode Explanations
+
+### Conversation Mode Cycle (`Tab`)
+
+Press `Tab` to cycle between conversation modes (Normal → Plan → Deep Research) when the input is empty.  
+When typing slash commands (`/`) or file mentions (`@`), `Tab` is used for autocomplete.
 
 ### Auto-Accept Mode (`Shift+Tab`)
 
@@ -60,6 +66,8 @@ When enabled, file edits are applied automatically without confirmation:
 ```
 
 **Use carefully:** Only enable when you trust the changes.
+
+**Need finer control?** Use `/permissions` to configure approval behavior for different action types before running larger tasks.
 
 ### Plan Mode (`Ctrl+P`)
 

--- a/docs-site/docs/03-features/slash-commands.md
+++ b/docs-site/docs/03-features/slash-commands.md
@@ -31,13 +31,22 @@ All commands start with `/`. Type `/` and press `Tab` for autocomplete.
 | `/skills`              | List loaded skills           |
 | `/plugin`              | Manage plugins/marketplaces  |
 | `/subagent`            | Configure subagents          |
-| `/permissions`         | Configure approvals (includes YOLO mode) |
+| `/permissions`         | Configure approval settings  |
 
+## Permissions & Approvals (`/permissions`)
+
+Use `/permissions` to configure which actions require manual confirmation before AdaL proceeds.
+
+Common uses:
+- Keep shell commands gated behind approval
+- Allow auto-apply for file edits in trusted workflows
+- Review and adjust safety behavior before enabling faster execution modes
 
 ## Tips
 
 - Use `/help` for information of all slash commands.
 - Run `/init` to generate AGENTS.md so that AdaL can understand your codebase better.
 - Use `/compact` after a milestone is achieved to save context and stay focused, or switch to a larger-context model via `/model` when needed.
+- Use `/permissions` before long tasks to match approval strictness to your risk tolerance.
 
-**Related:** [MCP](./mcp-support-proposed.md) · [BYOAK](./bring-your-own-api-key.md)
+**Related:** [Keyboard Shortcuts](./keyboard-shortcuts.md) · [MCP](./mcp-support-proposed.md) · [BYOAK](./bring-your-own-api-key.md)


### PR DESCRIPTION
## TL;DR
Adds clear user-facing docs for `/permissions` and corrects shortcut docs to match the actual CLI behavior (`Tab` cycles modes, `Shift+Tab` toggles auto-accept edits).

## What changed
- `docs-site/docs/03-features/slash-commands.md`
  - Clarified `/permissions` in Quick Reference
  - Added **Permissions & Approvals (`/permissions`)** section
  - Added usage tip for long tasks
  - Added related link to keyboard shortcuts
- `docs-site/docs/03-features/keyboard-shortcuts.md`
  - Added `Tab` to Modes & Toggles as mode cycle key
  - Added **Conversation Mode Cycle (`Tab`)** explanation
  - Kept `Shift+Tab` for auto-accept edit mode
  - Added `/permissions` cross-reference for fine-grained approval control

## Validation
- `npm run build` (from `docs-site/`) ✅

🌸 Generated with [AdaL](https://github.com/adal-cli/)