### PR TITLE
feat(docs): surface free trial and 2-minute install CTA on welcome page

### DIFF
--- a/docs-site/docs/01-getting-started/welcome.md
+++ b/docs-site/docs/01-getting-started/welcome.md
@@ -22,6 +22,14 @@ I am available as a terminal CLI — **AdaL CLI** (`adal`) — launched from you
 
 [> Watch the demo on YouTube](https://www.youtube.com/watch?v=3kLl0V4uDR8)
 
+> **Start free — 7-day trial, no credit card required.**
+
+### Get started in 2 minutes
+
+```bash
+curl -fsSL https://adal.sylph.ai/install.sh | bash
+```
+
 Talk is cheap, [let's get started](/getting-started/quickstart).
 
 


### PR DESCRIPTION
Add an explicit free-trial callout and a prominent curl install snippet on the docs homepage to reduce first-touch onboarding friction and improve conversion to first run.## TL;DR
Make first-touch onboarding clearer by surfacing the free trial and a 2-minute install command on the docs welcome page.

## What changed
- Added explicit callout: **Start free — 7-day trial, no credit card required**
- Added prominent install CTA with:
  - `curl -fsSL https://adal.sylph.ai/install.sh | bash`

## Why
Fresh-user friction analysis showed users miss the free trial and don’t see a clear immediate start path.

## Testing
- Docs-only change
- Verified diff includes only:
  - `docs-site/docs/01-getting-started/welcome.md`