### PR TITLE
feat(docs): add Quickstart link in top navbar

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -64,6 +64,11 @@ const config: Config = {
       },
       items: [
         {
+          to: '/getting-started/quickstart',
+          label: 'Quickstart',
+          position: 'left',
+        },
+        {
           to: '/',
           label: 'Get Started',
           position: 'left',


### PR DESCRIPTION
Surface Quickstart directly in top navigation so first-time users can reach installation steps in one click instead of going through generic docs entry points.