### PR TITLE
docs: add changelog entries for v1.0.2, v1.0.3, and v1.0.4

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,23 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [1.0.4] - 2026-04-20
+
+- Added support for Claude Opus 4.7 models
+- Minor UX polish and bug fixes
+
+## [1.0.3] - 2026-04-16
+
+- Added Cron Agent support and interactive `/cron` management in the CLI
+- Fixed ChatGPT subscription streaming issues
+- Fixed Anthropic model image input handling
+- Improved error message handling
+
+## [1.0.2] - 2026-04-03
+
+- Improved error messages display
+- Improved image generation requests stability
+
 ## [1.0.1] - 2026-03-31
 
 - Optimized the running memory of the AdaL session process


### PR DESCRIPTION
## Summary

Adds changelog entries for the three releases since v1.0.1:

- **v1.0.2** – Improved error messages display, improved image generation stability
- **v1.0.3** – Cron Agent support, ChatGPT streaming fix, Anthropic image input fix, better error handling
- **v1.0.4** – Claude Opus 4.7 support, minor UX polish and bug fixes

---

🌸 Generated with [AdaL](https://github.com/adal-cli/)