### PR TITLE
docs: sync AdaL 1.0.7 release notes

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -23,12 +23,15 @@ Use `/model` to browse four sections:
 
 Your selection persists across future AdaL sessions in this project.
 
+AdaL syncs the `/model` catalog from the live proxy, so model availability, promotion badges, and pricing metadata can update without requiring a new CLI release.
+
 ## Model Promotions
 
 Active limited-time discounts. Pricing adjustments are applied automatically — no promo code needed.
 
 | Model | Discount | Window | Slug |
 |-------|----------|--------|------|
+| **GPT-5.5** | **50% off** (launch week) | 2026-04-25 → 2026-05-02 | `gpt-5.5` |
 | **Claude Opus 4.7** | **50% off** (launch week) | 2026-04-19 → 2026-04-27 | `claude-opus-4-7` |
 | **DeepSeek V4 Pro** | **50% off** (launch week) | 2026-04-25 → 2026-05-02 | `deepseek-v4-pro` |
 | **DeepSeek V4 Flash** | **50% off** (launch week) | 2026-04-25 → 2026-05-02 | `deepseek-v4-flash` |
@@ -43,6 +46,7 @@ These are our top picks, balancing capability, speed, and cost:
 | Model | Provider | Context | Best For |
 |-------|----------|---------|----------|
 | **Claude Opus 4.7** 🆕 | Anthropic | 1M | Most capable: complex reasoning, agentic coding. **50% off launch week (ends Apr 27)** |
+| **GPT-5.5** 🆕 | OpenAI | 922K | SOTA reasoning for multi-step agentic tasks. **50% off launch week (ends May 2)** |
 | **GPT-5.3 Codex** | OpenAI | 272K | Coding-optimized for long-horizon tasks (default, price baseline) |
 | **Claude Sonnet 4.6** | Anthropic | 200K | Daily coding (slightly more expensive) |
 | **Claude Opus 4.6** | Anthropic | 200K | Complex reasoning, production code (2x more expensive) |
@@ -66,8 +70,9 @@ These are our top picks, balancing capability, speed, and cost:
 - **Claude Opus 4.5** — Slug: `claude-opus-4-5-20251101`
 - **Claude Haiku 4.5** — fast, cheap. Slug: `claude-haiku-4-5-20251001`
 
-### OpenAI (8 models)
+### OpenAI (9 models)
 
+- 🆕 **GPT-5.5** — 922K context, high-output reasoning model. **50% off launch week through May 2.** Slug: `gpt-5.5`
 - 🆕 **GPT-5.4** — Slug: `gpt-5.4`
 - ⭐ **GPT-5.3 Codex** — coding-optimized, default baseline. Slug: `gpt-5.3-codex`
 - **GPT-5.2** — Slug: `gpt-5.2`

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [1.0.7] - 2026-04-25
+
+- Added GPT-5.5 model support
+- Improved model catalog syncing for CLI, Web, and IDE launch flows
+- Improved model picker metadata display, including promotion badges and price tiers
+- Reduced Sentry noise in CI and added crash diagnostics documentation
+- Fixed reliability issues in model catalog and tool handling paths
+
 ## [1.0.6] - 2026-04-24
 
 - Fixed known issues in new model clients (DeepSeek & Kimi)


### PR DESCRIPTION
## TL;DR

Syncs the docs website with the AdaL 1.0.7 release updates.

## Changes

- Adds the 1.0.7 changelog entry
- Adds GPT-5.5 to Models & Billing
- Documents GPT-5.5 launch promotion metadata
- Notes that `/model` syncs from the live proxy catalog
- Updates the OpenAI model count from 8 to 9

## Testing

- `npm run build` in `docs-site` passed
- Manual diff review completed
- Secrets scan passed before commit

## Notes

- Left the existing untracked `.remotion/` directory untouched.

🌸 Generated with [AdaL](https://github.com/adal-cli/)