### PR TITLE
docs: sync AdaL 1.0.8 changelog

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [1.0.9] - 2026-05-01
+
+- Improved the UX of image gen with GPT and Gemini models
+- Fixed the windows crash bugs reported and improved product reliability
+
 ## [1.0.8] - 2026-04-25
 
 - Fixed image generation error and improved product reliability

--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,15 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [1.0.8] - 2026-04-25
+
+- Fixed image generation error and improved product reliability
+
+## [1.0.7] - 2026-04-25
+
+- Added GPT-5.5 model support
+- First-week 50%-off promotion for new models including GPT, DeepSeek, Kimi, and Claude
+
 ## [1.0.6] - 2026-04-24
 
 - Fixed known issues in new model clients (DeepSeek & Kimi)


### PR DESCRIPTION
## TL;DR

Syncs the public docs changelog with AdaL CLI 1.0.8 and the missing 1.0.7 release notes from the source CLI changelog.

## What changed

- Added `1.0.8` changelog entry for the image generation reliability fix.
- Added missing `1.0.7` changelog entry for GPT-5.5 support and launch-week model promotions.
- Kept this PR changelog-only to avoid mixing in the existing model-page updates from PR #113.

## Testing

- `npm run build --silent` from `docs-site/` ✅
- Staged diff secret scan ✅

## Intentional TODOs

None.

🌸 Generated with [AdaL](https://github.com/adal-cli/)