### PR TITLE
docs: add 1.1.1 changelog entry

### DIFF
--- a/docs-site/docs/CHANGELOG.md
+++ b/docs-site/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ slug: /changelog
 
 All notable changes to AdaL CLI will be documented in this file.
 
+## [1.1.1] - 2026-05-05
+
+- Improved subagent performance and token efficiency
+- Fixed Anthropic multiple image input inconsistencies
+- Added support for reading SVG files
+- Added a native installer for Windows users
+- Added Browser Use mode; press Tab to toggle among Plan, Deep Research, and Browser Use modes
+
 ## [1.0.9] - 2026-05-01
 
 - Improved the UX of image gen with GPT and Gemini models


### PR DESCRIPTION
## TL;DR
Add the 1.1.1 release notes to `docs-site/docs/CHANGELOG.md`.

## What changed
- Added a new `1.1.1` section near the top of the changelog
- Included the following release items:
  - Improved subagent performance and token efficiency
  - Fixed Anthropic multiple image input inconsistencies
  - Added SVG file reading support
  - Added native installer support for Windows users
  - Added Browser Use mode with Tab toggle across Plan / Deep Research / Browser Use

## Testing
- Documentation-only change (changelog update)
- Verified diff is limited to `docs-site/docs/CHANGELOG.md`

🌸 Generated with [AdaL](https://github.com/adal-cli/)