### PR TITLE
docs: add Desktop Preview guide

### DIFF
--- a/docs-site/docs/01-getting-started/adal-web.md
+++ b/docs-site/docs/01-getting-started/adal-web.md
@@ -1,36 +1,47 @@
 ---
 sidebar_position: 5
-title: AdaL Web (Preview)
-description: "AdaL Web (Preview) is a browser-based AI coding agent interface. Core capabilities are available today, with full feature parity planned. Launch with adal --web."
+title: AdaL Web (Legacy)
+description: "AdaL Web is the legacy browser interface. Use /ide from AdaL CLI to open Desktop when installed, or Web as a fallback."
 ---
 
-# AdaL Web (Preview)
+# AdaL Web (Legacy)
 
-AdaL Web is a browser-based interface for AdaL, launched from the same CLI package you already use.
+AdaL Web is the legacy browser-based interface for AdaL. New users should move to **AdaL Desktop** for the best visual workspace, project navigation, and review experience.
 
-## Launch
+:::tip Use `/ide`
+From AdaL CLI, use `/ide` to open the visual AdaL workspace. If AdaL Desktop is installed, `/ide` opens the Desktop app. If Desktop is not installed, AdaL opens the Web interface in your browser as a fallback.
+:::
 
-Open any terminal, `cd` to your project directory, and run:
+## Recommended path
 
-```bash
-adal --web
+For the best experience:
+
+1. Install **[AdaL Desktop](./desktop-app.md)**
+2. Open AdaL CLI in your project
+3. Run:
+
+```text
+/ide
 ```
 
-This automatically opens AdaL in your default browser at `http://localhost:xxxx`. The backend starts automatically — no extra setup needed.
+This gives you the Desktop workspace when available, while still keeping Web available as the legacy browser fallback.
 
-## Features
+## When Web opens
 
-AdaL Web shares the same agent engine and backend as AdaL CLI. Core capabilities are available today, with full feature parity planned.
+AdaL Web opens when you use `/ide` and AdaL Desktop is not installed or not available on your machine.
 
-### Available Now
+The Web interface runs in your default browser and keeps the similar AdaL Desktop workflow but not full support.
 
-- Conduct tasks with all tools, such as read, edit, web search, and bash tools
-- Subagent availability
-- Toggles for model selection, plan mode, auto-approve edits
-- Image upload and select project files as context from the sidebar
-- AGENTS.md creation from the sidebar
-- One-click memory compaction from the sidebar
-- Resume previous conversations from the sidebar
-- Diff viewer in the sidebar for reviewing changes
+## Move to Desktop
 
-Both AdaL interfaces (CLI and Web) connect to the same backend — your project context, session history, and more are shared.
+AdaL Web remains available for compatibility, but Desktop is the recommended visual interface going forward.
+
+Desktop gives you a more native experience for:
+
+- Project selection
+- Recent sessions
+- File browsing
+- Visual review of code changes
+- Focused project work outside the terminal
+
+See **[Desktop App (Preview)](./desktop-app.md)** to install and use the new Desktop experience.

--- a/docs-site/docs/01-getting-started/desktop-app.md
+++ b/docs-site/docs/01-getting-started/desktop-app.md
@@ -1,0 +1,128 @@
+---
+sidebar_position: 6
+title: Desktop App (Preview)
+description: "Install and use the AdaL Desktop app for a native AI-powered coding experience with project navigation, sessions, and review tools."
+---
+
+# Desktop App (Preview)
+
+AdaL Desktop is the native AdaL experience for working on projects in a visual workspace. It gives you a home screen for projects and recent sessions, a chat-first coding workflow, file browsing, and a dedicated review experience for checking changes before you move forward.
+
+:::note Preview
+AdaL Desktop is currently in preview. The CLI remains the recommended stable interface, while the desktop app is the best place to try the newest native workspace experience.
+:::
+
+## Why use AdaL Desktop?
+
+Use the desktop app when you want:
+
+- A native GUI app instead of a terminal UI
+- A project home screen with recent sessions
+- A workspace designed around chat, files, and code changes
+- Review Agent flow for undestanding and clustering PRs
+- The same AdaL account and agent experience across CLI and Desktop
+
+## Supported platforms
+
+AdaL Desktop is currently available for:
+
+| Platform | Package type |
+|----------|--------------|
+| macOS | `.dmg` |
+
+## Install
+
+Download the desktop installer from:
+
+[https://adal.sylph.ai/download/desktop](https://adal.sylph.ai/download/desktop)
+
+After installing, you can open AdaL Desktop in either of these ways:
+
+- Click the **AdaL** app icon from your applications menu
+- Open AdaL CLI in your project and run `/ide`
+
+## First launch
+
+When you open AdaL Desktop, you start on the home screen.
+
+From there you can:
+
+1. Pick a project folder
+2. Start a new task from the chat input
+3. Choose a workflow mode such as coding, research, or video
+4. Continue work from recent sessions
+5. Move into a focused workspace for the project
+
+The goal is to make starting work feel closer to opening an IDE: choose a project, describe what you want, and keep the conversation, files, and changes in one place.
+
+## Workspace experience
+
+The desktop workspace is designed for everyday development tasks:
+
+- Ask AdaL to explain, edit, debug, or improve code
+- Browse project files without leaving the app
+- Keep sessions organized by project
+- Switch between active work and previous conversations
+- Review generated changes visually before deciding what to do next
+
+## Review Agent
+
+AdaL Desktop puts review at the center of the coding workflow. The Review Agent helps you move from “AdaL changed code” to “I understand and trust these changes.”
+
+Instead of reviewing a long list of files one by one, the Review Agent organizes changes into a guided review experience.
+
+### Guided PR self-review
+
+Use the Review Agent when you want to review a PR.
+
+It helps you:
+
+- See what files changed
+- Compare before-and-after code in a visual diff
+- Understand why related changes belong together
+- Leave notes on specific parts of a diff
+- Track what has been reviewed and what still needs attention
+- Ask AdaL to revise or explain changes before you continue
+
+### PR clusters
+
+For larger tasks, AdaL groups related edits into **clusters**. A cluster is a set of changes that should be reviewed together, such as a UI update, an auth change, or a test update.
+
+This makes multi-file work easier to understand because you can review by intent instead of jumping through unrelated files.
+
+To make the cluster, open a PR branch with AdaL Desktop, trigger the review agent in the chat and ask the review agent to make a cluster for the PR.
+
+In a review, you may see:
+
+- Groups of related files
+- A guided walkthrough of each group
+- A visual sense of how parts of the change depend on each other
+- Clear progress as files are confirmed or marked for follow-up
+
+### Review notes and comments
+
+While reading a diff, you can select code and leave review notes. This is useful for questions, follow-ups, or issues you want AdaL to address.
+
+Review notes help you:
+
+- Mark something as resolved or unresolved
+- Keep feedback attached to the relevant code
+- Collect issues before asking AdaL to revise
+- Turn review feedback into GitHub PR comments when reviewing a pull request
+
+
+## Authentication
+
+AdaL Desktop uses the same AdaL account system as the CLI interface.
+
+On first use, the app opens a browser-based sign-in flow. After you authenticate, your desktop app is connected to your AdaL account.
+
+## Desktop vs CLI
+
+| Interface | Best for |
+|-----------|----------|
+| **CLI** | Fast terminal-native coding, automation, and keyboard-first workflows |
+| **Desktop** | Native project workspace, recent sessions, file browsing, and visual review |
+
+All AdaL interfaces share the same core AdaL experience, so you can choose the interface that best fits the way you like to work.
+


### PR DESCRIPTION
## TL;DR

Adds public documentation for AdaL Desktop Preview and updates AdaL Web docs to position Web as the legacy fallback opened by `/ide` when Desktop is unavailable.

## What changed

### Desktop App Preview
- Added a new getting-started page for AdaL Desktop.
- Documents installation via `https://adal.sylph.ai/download/desktop`.
- Explains launch options:
  - click the AdaL Desktop app icon
  - run `/ide` from AdaL CLI
- Focuses on UX: project selection, recent sessions, workspace flow, file browsing, and visual review.
- Expands the Review Agent section with guided self-review, change clusters, review notes, PR review, and focused review.

### AdaL Web
- Renames AdaL Web from Preview to Legacy.
- Removes promotion of `adal --web`.
- Promotes `/ide` as the recommended visual workspace entry point.
- Explains that `/ide` opens Desktop when installed and falls back to Web otherwise.
- Directs users toward Desktop as the recommended visual interface.

## Testing

- `npm run build` from `docs-site/` passes.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
