### PR TITLE
docs: sync model keys from registry

### DIFF
--- a/docs-site/docs/01-getting-started/models.md
+++ b/docs-site/docs/01-getting-started/models.md
@@ -29,11 +29,10 @@ Active limited-time discounts. Pricing adjustments are applied automatically —
 
 <!-- AUTO-GENERATED:PROMOTIONS:START -->
 | Model | Discount | Window | Slug |
-|-------|----------|--------|------|
-| **Claude Opus 4.7** | **50% off** (launch week) | 2026-04-19 → 2026-04-27 | `claude-opus-4-7` |
-| **DeepSeek V4 Pro** | **50% off** (launch week) | 2026-04-25 → 2026-05-02 | `deepseek-v4-pro` |
-| **DeepSeek V4 Flash** | **50% off** (launch week) | 2026-04-25 → 2026-05-02 | `deepseek-v4-flash` |
-| **Kimi K2.6** | **50% off** (launch week) | 2026-04-25 → 2026-05-02 | `kimi-k2.6` |
+| --- | --- | --- | --- |
+| — | — | — | No active promotions |
+
+> Promotions are sourced from the model registry and may update without notice. Check back here for the latest.
 <!-- AUTO-GENERATED:PROMOTIONS:END -->
 
 > Promotions are sourced from the model registry and may update without notice. Check back here for the latest.
@@ -55,61 +54,74 @@ These are our top picks, balancing capability, speed, and cost:
 
 ## All Models by Provider
 <!-- AUTO-GENERATED:ALL-MODELS:START -->
+
 > Legend: ⭐ recommended · 🆕 new
 
 ### Anthropic (8 models)
 
-- ⭐ 🆕 **Claude Opus 4.7** — latest flagship, 1M context, adaptive thinking. **50% off launch week through Apr 27.** Slug: `claude-opus-4-7`
-- ⭐ **Claude Sonnet 4.6** — daily coding workhorse, 200K context. Slug: `claude-sonnet-4-6`
-- **Claude Sonnet 4.6 (1M)** — 1M context variant. Slug: `claude-sonnet-4-6-1m`
-- ⭐ **Claude Opus 4.6** — complex reasoning, production code. Slug: `claude-opus-4-6`
-- 🆕 **Claude Opus 4.6 (1M)** — 1M context variant. Slug: `claude-opus-4-6-1m`
-- **Claude Sonnet 4.5** — Slug: `claude-sonnet-4-5-20250929`
-- **Claude Opus 4.5** — Slug: `claude-opus-4-5-20251101`
-- **Claude Haiku 4.5** — fast, cheap. Slug: `claude-haiku-4-5-20251001`
+- ⭐ **Claude Sonnet 4.6** — Fast daily coding · 1x price Slug: `anthropic-claude-sonnet-4-6`
+- **Claude Sonnet 4.6 (1M)** — Slug: `anthropic-claude-sonnet-4-6-1m`
+- 🆕 **Claude Opus 4.7** — Most capable Anthropic · 3x price, 1M native context Slug: `anthropic-claude-opus-4-7`
+- ⭐ **Claude Opus 4.6** — Deep reasoning & production code · 3x price Slug: `anthropic-claude-opus-4-6`
+- **Claude Opus 4.6 (1M)** — Slug: `anthropic-claude-opus-4-6-1m`
+- **Claude Sonnet 4.5** — Slug: `anthropic-claude-sonnet-4-5-20250929`
+- **Claude Opus 4.5** — Slug: `anthropic-claude-opus-4-5-20251101`
+- **Claude Haiku 4.5** — Slug: `anthropic-claude-haiku-4-5-20251001`
 
-### OpenAI (8 models)
+### OpenAI (9 models)
 
-- 🆕 **GPT-5.4** — Slug: `gpt-5.4`
-- ⭐ **GPT-5.3 Codex** — coding-optimized, default baseline. Slug: `gpt-5.3-codex`
-- **GPT-5.2** — Slug: `gpt-5.2`
-- **GPT-5.2 Codex** — Slug: `gpt-5.2-codex`
-- **GPT-5.1 Codex** — Slug: `gpt-5.1-codex`
-- **GPT-5.1 Codex Max** — Slug: `gpt-5.1-codex-max`
-- **GPT-5 Codex** — Slug: `gpt-5-codex`
-- **GPT-5 Mini** — Slug: `gpt-5-mini`
+- ⭐ **GPT-5.3 Codex** — Default · best value for coding · 1x baseline Slug: `openai-gpt-5.3-codex`
+- 🆕 **GPT-5.5** — SOTA reasoning · 4x premium price Slug: `openai-gpt-5.5`
+- ⭐ **GPT-5.4** — Stronger reasoning · 1.5x price Slug: `openai-gpt-5.4`
+- **GPT-5.2 Codex** — Slug: `openai-gpt-5.2-codex`
+- **GPT-5.1 Codex** — Slug: `openai-gpt-5.1-codex`
+- **GPT-5.1 Codex Max** — Slug: `openai-gpt-5.1-codex-max`
+- **GPT-5 Codex** — Slug: `openai-gpt-5-codex`
+- **GPT-5 Mini** — Slug: `openai-gpt-5-mini`
+- **GPT-5.2** — Slug: `openai-gpt-5.2`
 
 ### Google (4 models)
 
-- ⭐ **Gemini 3.1 Pro** — multi-modal reasoning, 1M context. Slug: `gemini-3.1-pro-preview`
-- **Gemini 3 Pro** — Slug: `gemini-3-pro-preview`
-- ⭐ **Gemini 3 Flash** — ultra-fast, 1M context. Slug: `gemini-3-flash-preview`
-- **Gemini 2.5 Pro** — Slug: `gemini-2.5-pro`
+- ⭐ **Gemini 3.1 Pro** — Multi-modal + design · 1.5x price, 1M context Slug: `google-gemini-3.1-pro-preview`
+- **Gemini 3 Pro** — Slug: `google-gemini-3-pro-preview`
+- ⭐ **Gemini 3 Flash** — Ultra-fast, simple tasks · 0.3x cheapest Slug: `google-gemini-3-flash-preview`
+- **Gemini 2.5 Pro** — Slug: `google-gemini-2.5-pro`
 
 ### Z.ai GLM (6 models)
 
-- ⭐ **GLM-5** — general coding & reasoning at lower cost. Slug: `glm-5`
-- 🆕 **GLM-5-Turbo** — Slug: `glm-5-turbo`
-- **GLM-4.7** — Slug: `glm-4.7`
-- **GLM-4.7 FlashX** — fast budget coding. Slug: `glm-4.7-flashx`
-- **GLM-4.7 Flash** — Slug: `glm-4.7-flash`
-- **GLM-4.5 Flash** — Slug: `glm-4.5-flash`
+- ⭐ **GLM-5** — Budget coding & reasoning · 0.5x price Slug: `zai-glm-5`
+- **GLM-5-Turbo** — Slug: `zai-glm-5-turbo`
+- **GLM-4.7** — Slug: `zai-glm-4.7`
+- **GLM-4.7 FlashX** — Slug: `zai-glm-4.7-flashx`
+- **GLM-4.7 Flash** — Slug: `zai-glm-4.7-flash`
+- **GLM-4.5 Flash** — Slug: `zai-glm-4.5-flash`
 
 ### MiniMax (4 models)
 
-- 🆕 **MiniMax M2.7** — Slug: `minimax-m2.7`
-- 🆕 **MiniMax M2.7 Highspeed** — Slug: `minimax-m2.7-highspeed`
-- **MiniMax M2.5** — Slug: `minimax-m2.5`
-- **MiniMax M2.5 Highspeed** — Slug: `minimax-m2.5-highspeed`
+- **MiniMax M2.5** — Slug: `minimax-minimax-m2.5`
+- **MiniMax M2.5 Highspeed** — Slug: `minimax-minimax-m2.5-highspeed`
+- 🆕 **MiniMax M2.7** — Slug: `minimax-minimax-m2.7`
+- **MiniMax M2.7 Highspeed** — Slug: `minimax-minimax-m2.7-highspeed`
 
 ### DeepSeek (2 models)
 
-- 🆕 **DeepSeek V4 Pro** — 936K context, 64K output, adaptive thinking. Strong reasoning at a fraction of the cost. **50% off launch week through May 2.** Slug: `deepseek-v4-pro`
-- 🆕 **DeepSeek V4 Flash** — 984K context, 16K output. Fast & budget-friendly thinking for high-volume coding loops. **50% off launch week through May 2.** Slug: `deepseek-v4-flash`
+- 🆕 **DeepSeek V4 Flash** — Slug: `deepseek-deepseek-v4-flash`
+- 🆕 **DeepSeek V4 Pro** — Slug: `deepseek-deepseek-v4-pro`
 
-### Moonshot (1 model)
+### Moonshot (1 models)
 
-- 🆕 **Kimi K2.6** — 224K context, 32K output, thinking enabled. Strong long-context reasoning. **50% off launch week through May 2.** Slug: `kimi-k2.6`
+- 🆕 **Kimi K2.6** — Slug: `kimi-kimi-k2.6`
+
+### ChatGPT Subscription (OAuth) (7 models)
+
+- **GPT-5.5** — Slug: `chatgpt_web-gpt-5.5`
+- **GPT-5.4** — Slug: `chatgpt_web-gpt-5.4`
+- **GPT-5.3 Codex** — Slug: `chatgpt_web-gpt-5.3-codex`
+- **GPT-5.2 Codex** — Slug: `chatgpt_web-gpt-5.2-codex`
+- **GPT-5.1 Codex** — Slug: `chatgpt_web-gpt-5.1-codex`
+- **GPT-5.1 Codex Max** — Slug: `chatgpt_web-gpt-5.1-codex-max`
+- **GPT-5 Codex** — Slug: `chatgpt_web-gpt-5-codex`
+
 <!-- AUTO-GENERATED:ALL-MODELS:END -->
 
 ## Image Models


### PR DESCRIPTION
🌸 Generated autonomously with [AdaL](https://github.com/adal-cli/)

Auto-synced model keys and promotions table from the platform model registry.

**What changed:** Replaces short slugs (e.g. `glm-4.7-flashx`) with full catalog keys (e.g. `zai-glm-4.7-flashx`) so users can copy from docs and switch models on the first try.