### PR TITLE
Harden installer: minisign signatures, manifest schema validation, opt-in tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths: ['install.sh', 'scripts/**', 'tests/**']
+  pull_request:
+    paths: ['install.sh', 'scripts/**', 'tests/**']
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Lint
+        run: |
+          shellcheck --shell=bash --severity=style install.sh
+          shellcheck scripts/sign-release.sh
+          shellcheck tests/*.sh
+
+  tests:
+    name: Installer tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install minisign
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y minisign
+      - name: Install minisign
+        if: runner.os == 'macOS'
+        run: brew install minisign
+      - name: Syntax check
+        run: bash -n install.sh && bash -n scripts/sign-release.sh
+      - name: Run test suite
+        run: bash tests/run.sh

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ First run opens the browser for authentication. See the [Quickstart](https://doc
 
 More on the [CLI product page](https://adalagent.ai/product/cli).
 
+## Security & releases
+
+The installer in this repo is the hardened reference implementation:
+
+- **Ed25519 signature verification** (minisign) of every downloaded artifact,
+  with a transition mode while signatures are being rolled out
+- **Manifest schema validation** — malformed manifests are refused, never
+  silently trusted
+- Strict semver + tarball-filename validation, checksum + size verification,
+  temp-dir cleanup on failure
+- **Install tracking is opt-in** (`--track` / `ADAL_TRACK=1`) and signed
+
+See [SECURITY.md](SECURITY.md) for the threat model and [RELEASE.md](RELEASE.md)
+for the release/signing runbook. The test suite in [`tests/`](tests/) runs in
+CI via `.github/workflows/ci.yml`.
+
 ## Documentation
 
 Everything is published at [docs.sylph.ai](https://docs.sylph.ai/).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,177 @@
+# Release & deploy runbook — AdaL CLI
+
+How to publish a signed release and keep the installers honest. This document
+is the companion to SECURITY.md; read that first.
+
+## Layout (observed from the live CDN)
+
+```
+s3://<bucket>/cli/
+├── latest                      # plain text: latest stable version, e.g. "1.5.7"
+├── beta                        # plain text: latest beta version
+├── manifests/
+│   └── manifest-<version>.json # one per version
+└── <version>/
+    ├── adal-<version>-darwin-arm64.tar.gz
+    ├── adal-<version>-darwin-arm64.tar.gz.minisig     ← NEW
+    ├── adal-<version>-darwin-x64.tar.gz
+    ├── adal-<version>-darwin-x64.tar.gz.minisig       ← NEW
+    ├── adal-<version>-linux-x64.tar.gz
+    ├── adal-<version>-linux-x64.tar.gz.minisig        ← NEW
+    ├── adal-<version>-linux-arm64.tar.gz
+    ├── adal-<version>-linux-arm64.tar.gz.minisig      ← NEW
+    └── adal-<version>-win32-x64.zip
+    └── adal-<version>-win32-x64.zip.minisig           ← NEW
+```
+
+## Manifest schema (enforced by install.sh)
+
+```json
+{
+  "version": "1.5.7",
+  "channel": "latest",
+  "platforms": {
+    "darwin-arm64": {
+      "filename": "adal-1.5.7-darwin-arm64.tar.gz",
+      "checksum": "<sha256 hex, 64 chars>",
+      "size": 74559913
+    }
+  }
+}
+```
+
+The installer **hard-fails** if `version` is missing, if the platform block is
+missing, if `checksum` is not 64 hex chars, if `size` is not a positive
+integer, or if `filename` does not match the URL being downloaded. Keep this
+schema stable — a rename silently disables verification for old installers.
+
+Platform keys currently accepted: `darwin-arm64`, `darwin-x64`, `linux-x64`,
+`linux-x64-musl`, `linux-arm64`, `win32-x64`. `linux-arm64-musl` is detected
+but **not published yet** — the installer prints a specific, actionable error
+for it instead of a generic one.
+
+## Release procedure (add to the existing release pipeline)
+
+```bash
+# 1. Build tarballs for every platform (existing pipeline step), then:
+
+# 2. Generate the manifest (existing step), then:
+
+# 3. Sign every artifact with the release key
+./scripts/sign-release.sh \
+  --version 1.5.7 \
+  --key     $ADAL_SIGNING_KEY \        # CI secret, NOT committed
+  --files   "dist/adal-1.5.7-*.tar.gz" "dist/adal-1.5.7-*.zip"
+
+# 4. Sanity-check the signatures
+./scripts/sign-release.sh --check --files "dist/adal-1.5.7-*"
+
+# 5. Upload to S3 (existing step): each <tarball> AND its <tarball>.minisig
+# 6. Update manifests/, latest, beta (existing steps)
+# 7. Deploy the hardened install.sh to adal.sylph.ai/install.sh
+```
+
+If the pipeline generates manifests itself, keep the schema above. If it
+already uploads `.minisig` files under a different convention, adjust
+`verify_signature` in install.sh accordingly.
+
+## First release with signing — key custody
+
+A keypair was generated for this change:
+
+- Private key: `adal-release.minisign` (this value is held out-of-band; it is
+  NOT in this repository).
+- Public key: already embedded in `install.sh` as `SIGNING_PUBLIC_KEY`.
+
+Actions:
+
+1. Copy the private key into the release pipeline's secret store (GitHub
+   Actions secret, AWS Secrets Manager, etc.).
+2. Confirm the pipeline can sign (step 3 above) before publishing.
+3. Delete the private key from the machine that generated it.
+4. If the pipeline must sign without human interaction, store the key
+   **encrypted** in the secrets manager and decrypt in the workflow. Do not
+   commit it, do not embed it in images.
+
+## CI matrix for linux-arm64-musl (close the gap)
+
+Add the missing build to the release matrix, then the existing
+`linux-x64-musl` logic in `detect_platform()` handles it automatically:
+
+```yaml
+# In the release workflow's build matrix:
+matrix:
+  include:
+    - os: ubuntu-latest
+      target: linux-arm64-musl
+      command: |
+        cargo build --release --target aarch64-unknown-linux-musl
+        # then bundle with the musl bun runtime (same as linux-x64-musl)
+```
+
+Verify the `apk add libstdc++ libgcc` runtime-deps path in
+`ensure_musl_runtime_deps()` against the produced artifact before shipping.
+
+## Tracking endpoint — server-side reference (HMAC + timestamp)
+
+Client behavior (`track_install` in install.sh, opt-in only):
+
+- Default OFF. Enabled by `--track` or `ADAL_TRACK=1`; `--no-track` /
+  `ADAL_NO_TRACK=1` always win.
+- `POST` with `content-type: application/json`:
+  `{"platform":"cli","channel":"stable|beta","event_type":"install|upgrade","version":"1.5.7","ts":<unix>,"nonce":"<32 hex>"}`
+- Headers: `X-Adal-Signature: <hex hmac-sha256(body, secret)>`,
+  `X-Adal-Ts: <unix>`, `X-Adal-Nonce: <32 hex>`.
+
+Minimal server-side validation (Python/FastAPI flavor):
+
+```python
+import hashlib, hmac, json, time
+
+SECRET = b"adal-cli-install-track-v1"  # keep in sync with install.sh
+MAX_AGE = 300  # seconds
+
+async def track(request):
+    body = await request.body()
+    sig = request.headers.get("X-Adal-Signature", "")
+    ts = int(request.headers.get("X-Adal-Ts", "0"))
+    if hmac.compare_digest(sig, hmac.new(SECRET, body, hashlib.sha256).hexdigest()) \
+       and 0 <= time.time() - ts <= MAX_AGE \
+       and request.headers.get("X-Adal-Nonce"):
+        record(json.loads(body))
+    # rate-limit by IP + User-Agent; treat signature as a filter, not identity
+    return 200
+```
+
+Reminder from SECURITY.md: the secret ships in a public installer, so the HMAC
+is an anti-naive-abuse filter, not authentication. Rate limiting is the real
+protection.
+
+## Installing the hardened installer
+
+```bash
+# Directly:
+curl -fsSL https://adal.sylph.ai/install.sh | bash
+
+# Specific version / channel:
+curl -fsSL https://adal.sylph.ai/install.sh | bash -s -- --version 1.5.7
+curl -fsSL https://adal.sylph.ai/install.sh | bash -s -- --version beta
+
+# Dockerfiles that install AdaL should pin + enforce signatures:
+RUN curl -fsSL https://adal.sylph.ai/install.sh | \
+    ADAL_REQUIRE_SIGNATURE=1 bash
+```
+
+## Testing
+
+```bash
+brew install shellcheck minisign   # or: apt install shellcheck minisign
+bash -n install.sh
+shellcheck --shell=bash install.sh scripts/*.sh tests/*.sh
+bash tests/run.sh
+```
+
+The E2E suite builds a fake signed release served over `file://` and verifies
+the full pipeline: happy path, tampered tarball, forged manifest, missing
+signature (transition + `ADAL_REQUIRE_SIGNATURE=1`), schema violations, channel
+resolution, and the HMAC tracking payload (captured by a local HTTP server).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,96 @@
+# Security — AdaL Installer
+
+This document describes the threat model of `install.sh`, what the hardening
+protects against, what remains intentionally unguarded, and what the SylphAI
+release pipeline must do to close the remaining gaps.
+
+## Threat model
+
+The installer runs as the invoking user (root in Dockerfiles). The relevant
+attackers are:
+
+| Attacker | Capability | Defended by |
+|---|---|---|
+| CDN/S3 bucket compromise | Rewrite any artifact + manifest served from `adal.sylph.ai` | **minisign Ed25519 signature** over each tarball; public key embedded in the installer |
+| Compromised manifest only | Modify checksums/sizes in `manifest-<ver>.json` | Signature: checksum is not a trust root, only a corruption check |
+| Content-delivery tampering | MITM or modify bytes in transit (non-TLS, or TLS breakage) | Signature covers the artifact bytes; checksum additionally verifies integrity |
+| Malicious version/filename injection | Craft `--version` or a tarball name that smuggles shell into URLs/paths | Strict semver regex + strict tarball filename regex |
+| Malformed/manipulated manifest | Omit or falsify checksum/size to weaken verification | Manifest schema validation; **hard fail** when a field is missing/invalid |
+
+## What the installer verifies, in order
+
+1. **Version string** — strict semver (`X.Y.Z` or `X.Y.Z-pre.n`) before it is
+   interpolated into any URL.
+2. **Manifest schema** — `version`, `platforms.<platform>.filename`,
+   `.checksum` (64 hex), `.size` (positive int) must all be present and valid;
+   otherwise the install refuses to proceed.
+3. **Downloaded size** — cheap first-line check against the manifest.
+4. **SHA-256 checksum** — against the manifest value (integrity check).
+5. **Ed25519 signature** — `minisign -Vm <tarball> -P <embedded pubkey>` using
+   the detached `<tarball>.minisig`. This is the tamper-protection layer.
+
+A `curl | bash` install can never be fully protected by the script itself —
+the user must review what they pipe to `bash` — but the combination above
+means an attacker who controls the CDN still cannot install signed payloads
+they did not author.
+
+## Transition mode (signature availability)
+
+The release pipeline does not yet publish `.minisig` files. To avoid breaking
+installs today, the installer runs in **transition mode**:
+
+- A `.minisig` file **is** published → it is *always* verified; a bad signature
+  is a hard failure (this was tested with a forged-manifest attack).
+- A `.minisig` file is **missing** → a loud warning is printed and install
+  continues with SHA-256 only.
+- `ADAL_REQUIRE_SIGNATURE=1` → missing signature or missing `minisign` binary
+  becomes a hard failure.
+
+**Rollout plan:** publish `.minisig` files for all platforms for ≥ 2 release
+cycles (so existing cached/old installers keep working), then flip the default
+in `install.sh` so a missing signature is a hard error, and finally advertise
+`ADAL_REQUIRE_SIGNATURE=1` in Dockerfiles/CI.
+
+## Key management
+
+- **Private key:** `adal-release.minisign` — must live ONLY in the release
+  pipeline (GitHub Actions secrets, a secrets manager, or a KMS-backed
+  signing service). Never commit it, never embed it, never send it to a
+  non-release machine.
+- **Public key:** embedded in `install.sh` as `SIGNING_PUBLIC_KEY`. Anyone can
+  see it — that is by design.
+- **Rotation:** generate a new keypair, embed the new public key in a new
+  `install.sh`, publish signatures with the new key for a full release cycle
+  (old installers still trust the old key), then move the old private key to
+  cold storage/delete it.
+- A keypair has already been generated and the public key embedded. **The
+  private key must be moved to the release pipeline and deleted from the
+  machine that generated it** (see RELEASE.md, "First release").
+
+## Known limitations (accepted)
+
+1. **HMAC tracking secret is extractable.** The tracking payload is signed
+   with a secret embedded in a public script. Anyone can read it, so the
+   signature is *obfuscation*, not authentication. The tracking endpoint must
+   not treat `X-Adal-Signature` as proof of identity; it should rate-limit by
+   IP/UA and validate the timestamp window. Reference server code is in
+   RELEASE.md.
+2. **No certificate pinning.** The connection to the release CDN uses standard
+   TLS. Pinning is not implemented because CDN cert rotation would break
+   installs; the signature layer is the tamper protection.
+3. **Local tarball installs** (`--local-tarball`) are not signed/checksummed —
+   by design, the file is already on the user's disk. The filename regex and
+   entry-point verification still apply.
+4. **The bootstrap is `curl | bash`.** The very first fetch of `install.sh`
+   itself is not authenticated. Consider publishing the script's SHA-256 on
+   the docs site as a secondary channel.
+
+## Org-side actions still required
+
+1. Wire the hardened `install.sh` into the private release pipeline and
+   deploy it to `adal.sylph.ai/install.sh`.
+2. Publish `.minisig` files for every artifact (scripts/sign-release.sh).
+3. Move the signing key into CI secrets; delete it from the generator machine.
+4. Add the `linux-arm64-musl` build to the release matrix (or stop advertising
+   it) — see RELEASE.md.
+5. Add HMAC + timestamp + rate-limit verification to the tracking endpoint.

--- a/TRANSFER.md
+++ b/TRANSFER.md
@@ -1,0 +1,67 @@
+# AdaL Release Signing Key — Transfer Instructions
+
+**This directory must be emptied once the key is safely stored in the release
+pipeline. Do not leave the private key on a laptop.**
+
+## Files
+
+| File | Content | Destination |
+|---|---|---|
+| `adal-release.minisign` | **PRIVATE** minisign secret key | Release pipeline secret store (GitHub Actions secret / AWS Secrets Manager / KMS). NEVER commit, embed, or email. |
+| `adal-release.pub` | Public key (safe to share) | Already embedded in `install.sh` as `SIGNING_PUBLIC_KEY`; keep a copy with the private key. |
+
+## Verification checksum
+
+SHA-256 of the private key (verify the copy you store against this):
+
+```
+435b2748198bbf2f891e69c019c60c06760965cf7edb5e44324c605a634204d9
+```
+
+On the target machine:
+
+```bash
+shasum -a 256 adal-release.minisign   # or: sha256sum adal-release.minisign
+```
+
+## ⚠️ Key rotation note (2026-08-05)
+
+The previous signing keypair was **rotated** because the private key blob was
+accidentally pasted into a terminal and a chat transcript. Do not use the old
+key (`RWTpQA9...`). The public key embedded in `install.sh` has been replaced
+with the one in this directory (`adal-release.pub`).
+
+## Store (pick one, in order of preference)
+
+1. **KMS / managed signing service** — if the pipeline supports signing with a
+   cloud KMS key, use it and delete this file entirely.
+2. **AWS Secrets Manager / GitHub Actions secret** — store the file contents
+   (the minisign secret key is a short text blob; store it as-is, preserving
+   the trailing newline), then decrypt/restore it inside the release workflow
+   only during the signing step.
+
+## Restore inside CI (GitHub Actions example)
+
+```yaml
+- name: Restore signing key
+  env:
+    ADAL_SIGNING_KEY: ${{ secrets.ADAL_SIGNING_KEY }}
+  run: |
+    printf '%s' "$ADAL_SIGNING_KEY" > adal-release.minisign
+    chmod 600 adal-release.minisign
+- name: Sign artifacts
+  run: ./scripts/sign-release.sh --version ${{ github.ref_name }} \
+       --key adal-release.minisign --files "dist/adal-*.tar.gz" "dist/adal-*.zip"
+```
+
+## After storage is confirmed
+
+Delete this directory:
+
+```bash
+rm -rf /Users/Brendan/.adal-release-key/
+```
+
+If the key is lost before it is stored, releases cannot be signed — rotate by
+regenerating a new keypair and shipping the new public key in a new install.sh
+(must be done together; see SECURITY.md "Key management").

--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,7 @@ TRACK_HMAC_SECRET="${ADAL_TRACK_HMAC_SECRET:-adal-cli-install-track-v1}"
 #   - Public key:  this value (RWT...).
 # ADAL_SIGNING_PUBLIC_KEY override exists so the test suite can verify against
 # a throwaway keypair.
-SIGNING_PUBLIC_KEY="${ADAL_SIGNING_PUBLIC_KEY:-RWTpQA9INHbbcb1MHIInAuhmJRnFaOn4Bf+Ye8oftDSkWK/SrYakIH3m}"
+SIGNING_PUBLIC_KEY="${ADAL_SIGNING_PUBLIC_KEY:-RWSZUbVM/EZtFEz8cAk+0zEnPI2cCSQFuSuK4xp0KUlP+Wdf71tvUl7C}"
 
 # Colors
 RED='\033[0;31m'

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,1065 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AdaL CLI Installer v2 (hardened)
+# Usage: curl -fsSL https://adal.sylph.ai/install.sh | bash                              # latest stable
+#        curl -fsSL https://adal.sylph.ai/install.sh | bash -s -- --version beta           # latest beta
+#        curl -fsSL https://adal.sylph.ai/install.sh | bash -s -- --version 1.0.2-beta.1   # specific version
+#
+# Installs to ~/.adal/versions/<version>/ with symlink at ~/.adal/bin/adal
+# Supports: macOS (arm64/x64), Linux (x64/arm64), Windows (x64 via Git Bash)
+#
+# Hardening vs upstream:
+#   * minisign (Ed25519) artifact signature verification with embedded public key
+#     - enforced when a .minisig file is published; transition mode warns otherwise
+#     - ADAL_REQUIRE_SIGNATURE=1 forces hard failure when signing is unavailable
+#   * Manifest schema validation (version / platforms.<platform>.checksum|size|filename)
+#     before anything is trusted
+#   * JSON parsing via jq -> python3 -> sed fallback (was sed-only)
+#   * Version string validated against semver regex before use in URLs
+#   * Local tarball filename validated against strict regex (blocks command injection)
+#   * Hard failure when the manifest/checksum is unavailable (no silent skip)
+#   * EXIT trap cleans the temp dir on error/signal
+#   * Extraction verified against the real entry point (adal / adal.cmd)
+#   * Install tracking is OPT-IN: requires ADAL_TRACK=1 or --track
+#     - requests carry an HMAC-SHA256 signature + timestamp + nonce
+#   * RELEASES_URL / TRACK_URL are env-overridable for mirrors and testing
+#   * Fixed 2>/devuhl typo -> 2>/dev/null
+
+APP="adal"
+RELEASES_URL="${ADAL_RELEASES_URL:-https://d35qg8ac0yw4p7.cloudfront.net/cli}"
+TRACK_URL="${ADAL_TRACK_URL:-https://adal.sylph.ai/api/installs/track}"
+# HMAC secret used to sign tracking payloads. This is obfuscation, not auth:
+# it is embedded in a public installer, so the server must not treat it as
+# proof of identity — only as a filter for accidental/naive abuse. See RELEASE.md
+# for the server-side verification reference.
+TRACK_HMAC_SECRET="${ADAL_TRACK_HMAC_SECRET:-adal-cli-install-track-v1}"
+
+# minisign public key for artifact verification.
+# Generate/rotate with: minisign -G -s adal-release.minisign -p adal-release.pub
+#   - Private key: keep OUT of the repo, in CI secrets or a secrets manager.
+#   - Public key:  this value (RWT...).
+# ADAL_SIGNING_PUBLIC_KEY override exists so the test suite can verify against
+# a throwaway keypair.
+SIGNING_PUBLIC_KEY="${ADAL_SIGNING_PUBLIC_KEY:-RWTpQA9INHbbcb1MHIInAuhmJRnFaOn4Bf+Ye8oftDSkWK/SrYakIH3m}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+MUTED='\033[0;2m'
+NC='\033[0m'
+
+# ┌─ Parse arguments ──────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+AdaL CLI Installer
+
+Usage:
+  curl -fsSL https://adal.sylph.ai/install.sh | bash
+  curl -fsSL https://adal.sylph.ai/install.sh | bash -s -- [OPTIONS]
+
+Options:
+  -v, --version <VER>   Install a specific version (e.g., 0.6.0-beta.1)
+  --local-tarball <PATH> Install from a local native tarball (skip download)
+  --no-modify-path      Don't modify shell config files (.zshrc, .bashrc, etc.)
+  --track               Opt in to anonymous install tracking (default: off)
+  --no-track            Disable tracking even if ADAL_TRACK=1 is set
+  -h, --help            Show this help message
+
+Environment:
+  ADAL_NO_TRACK=1           Disable tracking
+  ADAL_TRACK=1              Opt in to tracking (equivalent to --track)
+  ADAL_REQUIRE_SIGNATURE=1  Fail hard if a release has no minisign signature
+  ADAL_RELEASES_URL=...     Override the release base URL (mirrors/testing)
+EOF
+}
+
+requested_version=""
+no_modify_path=false
+local_tarball=""
+track_opt_in=false
+no_track=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -v|--version)
+      if [[ -n "${2:-}" ]]; then
+        requested_version="$2"; shift 2
+      else
+        echo -e "${RED}Error: --version requires a version argument${NC}" >&2; exit 1
+      fi ;;
+    --no-modify-path) no_modify_path=true; shift ;;
+    --track) track_opt_in=true; shift ;;
+    --no-track) no_track=true; shift ;;
+    --local-tarball)
+      if [[ -n "${2:-}" ]]; then
+        local_tarball="$2"; shift 2
+      else
+        echo -e "${RED}Error: --local-tarball requires a path argument${NC}" >&2; exit 1
+      fi ;;
+    *) echo -e "${YELLOW}Warning: Unknown option '$1'${NC}" >&2; shift ;;
+  esac
+done
+
+# ┌─ Platform detection ────────────────────────────────────────────────────────────
+
+detect_platform() {
+  local raw_os
+  raw_os=$(uname -s)
+
+  case "$raw_os" in
+    Darwin*)          os="darwin" ;;
+    Linux*)           os="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) os="win32" ;;
+    *)
+      echo -e "${RED}Unsupported operating system: $raw_os${NC}" >&2
+      echo -e "${MUTED}AdaL supports macOS, Linux, and Windows (via Git Bash).${NC}" >&2
+      exit 1 ;;
+  esac
+
+  local raw_arch
+  raw_arch=$(uname -m)
+
+  case "$raw_arch" in
+    x86_64|amd64)   arch="x64" ;;
+    arm64|aarch64)   arch="arm64" ;;
+    *)
+      echo -e "${RED}Unsupported architecture: $raw_arch${NC}" >&2
+      exit 1 ;;
+  esac
+
+  # Detect Rosetta 2: if running x64 under emulation on ARM Mac, use arm64
+  if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
+    if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+      arch="arm64"
+      echo -e "${MUTED}Detected Rosetta 2 — using native arm64 binary${NC}"
+    fi
+  fi
+
+  # Detect musl (Alpine Linux)
+  is_musl=false
+  if [ "$os" = "linux" ]; then
+    if [ -f /etc/alpine-release ]; then
+      is_musl=true
+    elif command -v ldd >/dev/null 2>&1; then
+      if ldd --version 2>&1 | grep -qi musl; then
+        is_musl=true
+      fi
+    fi
+  fi
+
+  PLATFORM="${os}-${arch}"
+
+  # On musl-libc Linux (Alpine and similar), pick the musl-native tarball
+  # instead of the glibc one — glibc binaries (including the bundled Bun
+  # runtime) cannot load when /lib64/ld-linux-x86-64.so.2 is absent.
+  if [ "$is_musl" = true ] && [ "$os" = "linux" ]; then
+    PLATFORM="${PLATFORM}-musl"
+    echo -e "${MUTED}Detected musl libc (Alpine and similar) — using ${PLATFORM} tarball${NC}"
+  fi
+
+  # Validate platform is supported.
+  case "$PLATFORM" in
+    darwin-arm64|darwin-x64|linux-x64|linux-x64-musl|linux-arm64|win32-x64) ;;
+    *)
+      echo -e "${RED}Unsupported platform: $PLATFORM${NC}" >&2
+      echo -e "${MUTED}Supported: macOS (arm64/x64), Linux (x64 glibc/musl, arm64 glibc), Windows (x64)${NC}" >&2
+      if [ "$PLATFORM" = "linux-arm64-musl" ]; then
+        echo -e "${MUTED}Note: linux-arm64-musl builds are not published yet.${NC}" >&2
+        echo -e "${MUTED}Workaround: install the glibc build under a musl-compatible runtime, or open an issue on https://github.com/SylphAI-Inc/adal-cli${NC}" >&2
+      fi
+      exit 1 ;;
+  esac
+}
+
+# ┌─ musl runtime deps ────────────────────────────────────────────────────────────
+
+# Bun in the musl tarball is dynamically linked against libstdc++ and libgcc_s
+# (Bun's C++ runtime + GCC's unwinder). Slim Alpine base images (including
+# python:3.11-alpine, alpine:3.x, and most SWE-bench Alpine variants) don't
+# ship these by default — exec'ing adal then prints a flood of "Error
+# loading shared library libstdc++.so.6 / libgcc_s.so.1" messages. Install
+# them via apk before extracting the tarball.
+ensure_musl_runtime_deps() {
+  [ "$is_musl" = true ] || return 0
+  [ "$os" = "linux" ] || return 0
+
+  # Skip if both libs are already present.
+  if ldconfig -p 2>/dev/null | grep -q libstdc++.so.6 && \
+     ldconfig -p 2>/dev/null | grep -q libgcc_s.so.1; then
+    return 0
+  fi
+  if [ -f /usr/lib/libstdc++.so.6 ] && [ -f /usr/lib/libgcc_s.so.1 ]; then
+    return 0
+  fi
+
+  if ! command -v apk >/dev/null 2>&1; then
+    echo -e "${YELLOW}musl detected but apk is not available; cannot auto-install libstdc++/libgcc.${NC}" >&2
+    echo -e "${MUTED}Please install them manually before running adal.${NC}" >&2
+    return 0
+  fi
+
+  echo -e "${MUTED}Installing libstdc++ and libgcc (required by bundled Bun runtime)...${NC}"
+  if [ "$(id -u 2>/dev/null)" = "0" ]; then
+    apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || \
+      echo -e "${YELLOW}apk add libstdc++ libgcc failed; adal may not start.${NC}" >&2
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || \
+      echo -e "${YELLOW}sudo apk add libstdc++ libgcc failed; adal may not start.${NC}" >&2
+  else
+    echo -e "${YELLOW}Not running as root and sudo not available — please run: apk add libstdc++ libgcc${NC}" >&2
+  fi
+}
+
+# ┌─ Download helpers ────────────────────────────────────────────────────────────
+
+DOWNLOADER=""
+detect_downloader() {
+  if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+  elif command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+  else
+    echo -e "${RED}Either curl or wget is required but neither is installed${NC}" >&2
+    exit 1
+  fi
+}
+
+download_file() {
+  local url="$1"
+  local output="${2:-}"
+
+  if [ "$DOWNLOADER" = "curl" ]; then
+    if [ -n "$output" ]; then
+      curl -fsSL -o "$output" "$url"
+    else
+      curl -fsSL "$url"
+    fi
+  elif [ "$DOWNLOADER" = "wget" ]; then
+    if [ -n "$output" ]; then
+      wget -q -O "$output" "$url"
+    else
+      wget -q -O - "$url"
+    fi
+  fi
+}
+
+download_with_progress() {
+  local url="$1"
+  local output="$2"
+  local expected_size="$3"  # optional, in bytes
+
+  # Start download in background
+  if [ "$DOWNLOADER" = "curl" ]; then
+    curl -fsSL -o "$output" "$url" &
+  elif [ "$DOWNLOADER" = "wget" ]; then
+    wget -q -O "$output" "$url" &
+  fi
+  local dl_pid=$!
+
+  # Show progress if we know the expected size
+  if [ -n "$expected_size" ] && [ "$expected_size" -gt 0 ] 2>/dev/null; then
+    local last_pct=-1
+    while kill -0 "$dl_pid" 2>/dev/null; do
+      if [ -f "$output" ]; then
+        local current_size
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+          current_size=$(stat -f%z "$output" 2>/dev/null || echo 0)
+        else
+          current_size=$(stat -c%s "$output" 2>/dev/null || echo 0)
+        fi
+        local pct=$((current_size * 100 / expected_size))
+        [ "$pct" -gt 100 ] && pct=100
+        if [ "$pct" -ne "$last_pct" ]; then
+          printf "\r${MUTED}🌸 Installing ${NC}${APP} ${MUTED}v${VERSION} (%d%%)${NC}" "$pct" >&2
+          last_pct=$pct
+        fi
+      fi
+      sleep 0.5
+    done
+    printf "\r${MUTED}🌸 Installing ${NC}${APP} ${MUTED}v${VERSION} (100%%)${NC}\n" >&2
+  fi
+
+  wait "$dl_pid"
+  return $?
+}
+
+# ┌─ Checksum verification ──────────────────────────────────────────────────────────
+
+verify_checksum() {
+  local file="$1"
+  local expected="$2"
+
+  local actual
+  if command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$file" | cut -d' ' -f1)
+  else
+    echo -e "${YELLOW}Warning: Cannot verify checksum (no shasum or sha256sum)${NC}" >&2
+    return 0
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    echo -e "${RED}Checksum verification failed!${NC}" >&2
+    echo -e "${MUTED}  Expected: $expected${NC}" >&2
+    echo -e "${MUTED}  Actual:   $actual${NC}" >&2
+    return 1
+  fi
+}
+
+# ┌─ Signature verification (minisign / Ed25519) ───────────────────────────────────
+
+# Verify the artifact against its detached .minisig signature and the embedded
+# public key. Transition mode: while the release pipeline does not yet publish
+# .minisig files, a missing signature warns but does not fail; once signatures
+# are published they are ALWAYS enforced (a bad signature is a hard failure).
+# Set ADAL_REQUIRE_SIGNATURE=1 to fail hard when signing is unavailable.
+verify_signature() {
+  local file="$1"
+  local sig_file="$2"
+  local public_key="$3"
+
+  if ! command -v minisign >/dev/null 2>&1; then
+    if [ "${ADAL_REQUIRE_SIGNATURE:-0}" = "1" ]; then
+      echo -e "${RED}Error: ADAL_REQUIRE_SIGNATURE=1 requires minisign (brew install minisign / apt install minisign)${NC}" >&2
+      exit 1
+    fi
+    echo -e "  ${YELLOW}⚠ minisign not installed — skipping signature verification (SHA256 still enforced)${NC}"
+    return 0
+  fi
+
+  if [ ! -s "$sig_file" ]; then
+    if [ "${ADAL_REQUIRE_SIGNATURE:-0}" = "1" ]; then
+      echo -e "${RED}Error: Signature file missing: $sig_file${NC}" >&2
+      exit 1
+    fi
+    echo -e "  ${YELLOW}⚠ No signature published for this release yet — relying on SHA256 checksum${NC}"
+    return 0
+  fi
+
+  if ! minisign -Vm "$file" -P "$public_key" -x "$sig_file" >/dev/null 2>&1; then
+    echo -e "${RED}Signature verification failed!${NC}" >&2
+    echo -e "${MUTED}  File:      $file${NC}" >&2
+    echo -e "${MUTED}  Signature: $sig_file${NC}" >&2
+    return 1
+  fi
+  echo -e "  ${GREEN}✅ Ed25519 signature verified${NC}"
+  return 0
+}
+
+# ┌─ JSON parsing (jq -> python3 -> sed fallback) ─────────────────────────────────
+
+# Extract a string value from JSON: json_get '{"key":"val"}' "key" → val
+json_get() {
+  local json="$1"
+  local key="$2"
+
+  if command -v jq >/dev/null 2>&1; then
+    echo "$json" | jq -r --arg k "$key" '
+      .[$k] // empty | if type == "string" then . else tostring end
+    ' 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    echo "$json" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    v = d.get(sys.argv[1])
+    if v is not None:
+        print(v)
+except Exception:
+    pass
+' "$key" 2>/dev/null || true
+  else
+    echo "$json" | sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+  fi
+}
+
+# Extract a number value from JSON
+json_get_num() {
+  local json="$1"
+  local key="$2"
+
+  if command -v jq >/dev/null 2>&1; then
+    echo "$json" | jq -r --arg k "$key" '
+      .[$k] | if type == "number" then tostring else empty end
+    ' 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    echo "$json" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    v = d.get(sys.argv[1])
+    if isinstance(v, (int, float)):
+        print(v)
+except Exception:
+    pass
+' "$key" 2>/dev/null || true
+  else
+    echo "$json" | sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p" | head -1
+  fi
+}
+
+# Extract a platform block from manifest JSON.
+# The manifest nests platforms under a "platforms" key ({"platforms": {...}});
+# also tolerate top-level placement for forward compatibility.
+json_get_platform() {
+  local json="$1"
+  local platform="$2"
+
+  if command -v jq >/dev/null 2>&1; then
+    echo "$json" | jq -c --arg p "$platform" '(.platforms[$p] // .[$p]) // empty' 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    echo "$json" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    v = d.get("platforms", {}).get(sys.argv[1]) or d.get(sys.argv[1])
+    if isinstance(v, dict):
+        print(json.dumps(v))
+except Exception:
+    pass
+' "$platform" 2>/dev/null || true
+  else
+    echo "$json" | tr -d '\n' | sed -n "s/.*\"$platform\"[[:space:]]*:[[:space:]]*{\([^}]*\)}.*/\1/p"
+  fi
+}
+
+# ┌─ Manifest schema validation ────────────────────────────────────────────────────
+
+# Validate that the manifest has the expected shape before trusting any value.
+# Returns 0 with CHECKSUM/SIZE populated via echo, 1 on schema failure.
+parse_manifest() {
+  local manifest="$1"
+  local version="$2"
+  local platform="$3"
+  local expected_filename="$4"
+
+  # version must be a string and match the requested version
+  local mver
+  mver=$(json_get "$manifest" "version")
+  if [ -z "$mver" ]; then
+    echo -e "${RED}Error: Manifest missing 'version' field${NC}" >&2
+    return 1
+  fi
+  if [ "$mver" != "$version" ]; then
+    echo -e "${YELLOW}Warning: manifest version '$mver' does not match requested '$version'${NC}" >&2
+  fi
+
+  # platform block must exist
+  local block
+  block=$(json_get_platform "$manifest" "$platform")
+  if [ -z "$block" ]; then
+    echo -e "${RED}Error: Manifest has no entry for platform '$platform'${NC}" >&2
+    return 1
+  fi
+
+  # checksum must be 64 hex chars
+  local checksum
+  checksum=$(json_get "$block" "checksum")
+  if [ -z "$checksum" ] || ! echo "$checksum" | grep -qE '^[a-fA-F0-9]{64}$'; then
+    echo -e "${RED}Error: Manifest platform '$platform' has invalid/missing 'checksum' (expected 64 hex chars)${NC}" >&2
+    return 1
+  fi
+
+  # size must be a positive integer
+  local size
+  size=$(json_get_num "$block" "size")
+  if [ -z "$size" ] || ! echo "$size" | grep -qE '^[0-9]+$' || [ "$size" -le 0 ] 2>/dev/null; then
+    echo -e "${RED}Error: Manifest platform '$platform' has invalid/missing 'size'${NC}" >&2
+    return 1
+  fi
+
+  # filename must match what we are about to download
+  local fname
+  fname=$(json_get "$block" "filename")
+  if [ -n "$fname" ] && [ "$fname" != "$expected_filename" ]; then
+    echo -e "${RED}Error: Manifest filename '$fname' does not match expected '$expected_filename'${NC}" >&2
+    return 1
+  fi
+
+  echo "$checksum"
+  echo "$size"
+  return 0
+}
+
+# ┌─ Version validation ────────────────────────────────────────────────────────────
+
+# Strict semver check — blocks path traversal / injection via the version string,
+# which is interpolated into download URLs below.
+validate_version() {
+  local ver="$1"
+  if ! echo "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$'; then
+    echo -e "${RED}Error: Invalid version format: $ver${NC}" >&2
+    echo -e "${MUTED}Expected semver like 1.2.3 or 1.2.3-beta.1${NC}" >&2
+    exit 1
+  fi
+}
+
+# ┌─ Version resolution ────────────────────────────────────────────────────────────
+
+resolve_version() {
+  if [ -n "$requested_version" ]; then
+    # Strip leading 'v' if present
+    requested_version="${requested_version#v}"
+    VERSION="$requested_version"
+
+    # Support channel names (e.g., "beta") — resolve to actual version number
+    if echo "$VERSION" | grep -qE '^[a-z]+$'; then
+      echo -e "${MUTED}Resolving channel '$VERSION'...${NC}"
+      local resolved
+      resolved=$(download_file "$RELEASES_URL/$VERSION" 2>/dev/null | tr -d '[:space:]')
+      if [ -z "$resolved" ]; then
+        echo -e "${RED}Error: Channel '${VERSION}' not found${NC}" >&2
+        exit 1
+      fi
+      VERSION="$resolved"
+      validate_version "$VERSION"
+    else
+      validate_version "$VERSION"
+      # Verify the version exists on S3 by checking the manifest
+      local http_status
+      if [ "$DOWNLOADER" = "curl" ]; then
+        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "$RELEASES_URL/manifests/manifest-${VERSION}.json")
+      else
+        http_status=$(wget --spider -S "$RELEASES_URL/manifests/manifest-${VERSION}.json" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}')
+      fi
+
+      if [ "$http_status" = "404" ] || [ "$http_status" = "403" ]; then
+        echo -e "${RED}Error: Version ${VERSION} not found${NC}" >&2
+        exit 1
+      fi
+    fi
+  else
+    # Fetch latest version from S3 channel pointer file
+    echo -e "${MUTED}Checking for latest version...${NC}"
+    VERSION=$(download_file "$RELEASES_URL/latest" 2>/dev/null | tr -d '[:space:]')
+
+    if [ -z "$VERSION" ]; then
+      echo -e "${RED}Failed to determine latest version${NC}" >&2
+      exit 1
+    fi
+    validate_version "$VERSION"
+  fi
+}
+
+# ┌─ Check existing installation ────────────────────────────────────────────────────
+
+INSTALL_BASE="$HOME/.adal"
+VERSIONS_DIR="$INSTALL_BASE/versions"
+BIN_DIR="$INSTALL_BASE/bin"
+
+check_existing() {
+  if [ -d "$VERSIONS_DIR/$VERSION" ]; then
+    echo -e "${MUTED}Version $VERSION is already installed${NC}"
+    # Still update symlinks and PATH in case they're broken or missing.
+    setup_symlinks
+    cleanup_old_versions
+    setup_path
+    setup_github_actions_path
+    detect_npm_install
+    print_success
+    exit 0
+  fi
+}
+
+# ┌─ Local tarball install ──────────────────────────────────────────────────────────
+
+install_from_local_tarball() {
+  local tarball="$1"
+
+  if [ ! -f "$tarball" ]; then
+    echo -e "${RED}Error: Local tarball not found: $tarball${NC}" >&2
+    exit 1
+  fi
+
+  # Extract version from tarball filename: adal-<VERSION>-<PLATFORM>.tar.gz
+  local basename_tar
+  basename_tar=$(basename "$tarball")
+
+  # Strict filename validation — blocks command injection via crafted filenames
+  # (e.g. adal-1.0.0-$(reboot)-linux-x64.tar.gz) before any parsing.
+  if ! [[ "$basename_tar" =~ ^adal-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?-(darwin|linux|win32)-(x64|arm64)(-musl)?\.(tar\.gz|zip)$ ]]; then
+    echo -e "${RED}Error: Invalid tarball filename: $basename_tar${NC}" >&2
+    echo -e "${MUTED}Expected format: adal-<VERSION>-<PLATFORM>.tar.gz (e.g. adal-1.2.3-linux-x64-musl.tar.gz)${NC}" >&2
+    exit 1
+  fi
+
+  # Strip extension (.tar.gz or .zip)
+  local stem="${basename_tar%.tar.gz}"
+  stem="${stem%.zip}"
+  # Extract version: adal-<VERSION>-<PLATFORM> → strip "adal-" prefix, then strip "-<PLATFORM>" suffix
+  VERSION=$(echo "$stem" | sed 's/^adal-//; s/-\(darwin\|linux\|win32\)-.*$//')
+
+  if [ -z "$VERSION" ]; then
+    echo -e "${RED}Error: Cannot determine version from tarball filename: $basename_tar${NC}" >&2
+    echo -e "${MUTED}Expected format: adal-<VERSION>-<PLATFORM>.tar.gz${NC}" >&2
+    exit 1
+  fi
+
+  printf "\n${MUTED}🌸 Installing ${NC}${APP} ${MUTED}v${VERSION} (from local tarball)${NC}\n"
+
+  # Extract
+  mkdir -p "$VERSIONS_DIR"
+  tar -xzf "$tarball" -C "$VERSIONS_DIR"
+
+  # The tarball extracts to adal-<version>/ — rename to just <version>/
+  if [ -d "$VERSIONS_DIR/adal-$VERSION" ]; then
+    rm -rf "${VERSIONS_DIR:?}/$VERSION"
+    mv "$VERSIONS_DIR/adal-$VERSION" "$VERSIONS_DIR/$VERSION"
+  fi
+
+  # Verify extraction — the tarball contains a bundled Bun runtime and adal-cli.js
+  if [ ! -f "$VERSIONS_DIR/$VERSION/adal-cli.js" ]; then
+    echo -e "${RED}Error: Extraction failed — adal-cli.js not found${NC}" >&2
+    exit 1
+  fi
+}
+
+# ┌─ Main install logic ─────────────────────────────────────────────────────────────
+
+install_version() {
+  printf "\n${MUTED}🌸 Installing ${NC}${APP} ${MUTED}v${VERSION}${NC}"
+
+  local archive_ext="tar.gz"
+  if [ "$os" = "win32" ]; then
+    archive_ext="zip"
+  fi
+
+  local filename="adal-${VERSION}-${PLATFORM}.${archive_ext}"
+  local download_url="$RELEASES_URL/${VERSION}/${filename}"
+
+  # Download manifest for checksum
+  local manifest_url="$RELEASES_URL/manifests/manifest-${VERSION}.json"
+  local manifest_json
+  manifest_json=$(download_file "$manifest_url" 2>/dev/null || echo "")
+
+  # Download tarball
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  # Clean up the temp dir even on error/signal/interrupt.
+  trap 'rm -rf "$tmp_dir"' EXIT
+  local archive_path="$tmp_dir/$filename"
+
+  # Download with single-line progress percentage
+  if ! download_with_progress "$download_url" "$archive_path" ""; then
+    echo -e "${RED}Download failed${NC}" >&2
+    exit 1
+  fi
+
+  # Schema-validate the manifest and extract checksum + size. The manifest was
+  # confirmed to exist during resolve_version(), so a failure here is a hard
+  # error — refuse to install unverified artifacts.
+  local expected_checksum=""
+  local expected_size=""
+  if [ -z "$manifest_json" ]; then
+    echo -e "${RED}Error: Manifest not found: $manifest_url${NC}" >&2
+    echo -e "${MUTED}Refusing to install without integrity verification.${NC}" >&2
+    exit 1
+  fi
+  local parsed
+  parsed=$(parse_manifest "$manifest_json" "$VERSION" "$PLATFORM" "$filename") || {
+    echo -e "${MUTED}Refusing to install an unverified artifact.${NC}" >&2
+    exit 1
+  }
+  expected_checksum=$(echo "$parsed" | sed -n '1p')
+  expected_size=$(echo "$parsed" | sed -n '2p')
+
+  # Verify size before checksum — cheap first-line integrity check
+  if [ -n "$expected_size" ] && [ "$expected_size" -gt 0 ] 2>/dev/null; then
+    local actual_size
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      actual_size=$(stat -f%z "$archive_path")
+    else
+      actual_size=$(stat -c%s "$archive_path")
+    fi
+    if [ "$actual_size" != "$expected_size" ]; then
+      echo -e "${RED}Error: Downloaded size $actual_size does not match manifest size $expected_size${NC}" >&2
+      exit 1
+    fi
+  fi
+
+  # Verify checksum
+  if ! verify_checksum "$archive_path" "$expected_checksum"; then
+    exit 1
+  fi
+
+  # Verify Ed25519 signature (enforced when a .minisig file is published)
+  local sig_url="$download_url.minisig"
+  if ! download_file "$sig_url" "$archive_path.minisig" 2>/dev/null; then
+    : # no signature published yet — verify_signature handles the warning
+  fi
+  if ! verify_signature "$archive_path" "$archive_path.minisig" "$SIGNING_PUBLIC_KEY"; then
+    exit 1
+  fi
+
+  # Extract
+  mkdir -p "$VERSIONS_DIR"
+
+  if [ "$os" = "linux" ]; then
+    tar -xzf "$archive_path" -C "$VERSIONS_DIR"
+  else
+    # macOS and Windows (Git Bash)
+    if command -v tar >/dev/null 2>&1 && [ "$archive_ext" = "tar.gz" ]; then
+      tar -xzf "$archive_path" -C "$VERSIONS_DIR"
+    elif command -v unzip >/dev/null 2>&1; then
+      unzip -q "$archive_path" -d "$VERSIONS_DIR"
+    else
+      echo -e "${RED}Error: No extraction tool available (need tar or unzip)${NC}" >&2
+      exit 1
+    fi
+  fi
+
+  # The tarball extracts to adal-<version>/ — rename to just <version>/
+  if [ -d "$VERSIONS_DIR/adal-$VERSION" ]; then
+    # Remove existing version dir if somehow there
+    rm -rf "${VERSIONS_DIR:?}/$VERSION"
+    mv "$VERSIONS_DIR/adal-$VERSION" "$VERSIONS_DIR/$VERSION"
+  fi
+
+  # Verify extraction — check the real entry point for this platform
+  if [ "$os" = "win32" ]; then
+    if [ ! -f "$VERSIONS_DIR/$VERSION/adal.cmd" ]; then
+      echo -e "${RED}Error: Extraction failed — adal.cmd not found${NC}" >&2
+      exit 1
+    fi
+  else
+    if [ ! -x "$VERSIONS_DIR/$VERSION/adal" ]; then
+      echo -e "${RED}Error: Extraction failed — adal not found or not executable${NC}" >&2
+      exit 1
+    fi
+  fi
+
+  # Cleanup
+  rm -rf "$tmp_dir"
+  trap - EXIT
+
+  # Track after successful extraction — guarantees the row represents a real,
+  # finished install/upgrade, not a failed/aborted attempt.
+  track_install
+}
+
+# ┌─ Symlink setup ────────────────────────────────────────────────────────────────
+
+setup_symlinks() {
+  mkdir -p "$BIN_DIR"
+
+  # Update 'current' symlink
+  local current_link="$VERSIONS_DIR/current"
+  rm -f "$current_link"
+  ln -s "$VERSION" "$current_link"
+
+  # Create bin/adal → ../versions/current/adal
+  local bin_target="$BIN_DIR/adal"
+  rm -f "$bin_target"
+
+  if [ "$os" = "win32" ]; then
+    # On Windows/Git Bash, create a shell wrapper instead of symlink
+    cat > "$bin_target" << 'WINWRAP'
+#!/usr/bin/env sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../versions/current/adal.cmd" "$@"
+WINWRAP
+    chmod +x "$bin_target"
+  else
+    ln -s "../versions/current/adal" "$bin_target"
+  fi
+
+  setup_immediate_path_shim
+
+  # Symlinks created silently
+}
+
+path_contains_dir() {
+  local dir="$1"
+  [[ ":$PATH:" == *":$dir:"* ]]
+}
+
+create_adal_shim() {
+  local target_dir="$1"
+  local shim_path="$target_dir/adal"
+  local expected_target="$VERSIONS_DIR/current/adal"
+
+  [ -d "$target_dir" ] || return 1
+  [ -w "$target_dir" ] || return 1
+
+  if [ -L "$shim_path" ] && [ "$(readlink "$shim_path" 2>/dev/null || true)" = "$expected_target" ]; then
+    return 2  # Already correct; no user-visible work happened.
+  fi
+
+  # Avoid clobbering unrelated real files. Symlinks are safe to refresh because
+  # previous npm/native installs commonly expose commands as symlinks.
+  if [ -e "$shim_path" ] && [ ! -L "$shim_path" ]; then
+    return 1
+  fi
+
+  rm -f "$shim_path"
+  ln -s "$expected_target" "$shim_path"
+  return 0
+}
+
+setup_immediate_path_shim() {
+  [ "$os" != "win32" ] || return 0
+
+  # Best-effort same-terminal support for `curl | bash` followed by `adal`.
+  # The installer cannot change the parent shell's PATH, so only use selected
+  # directories that are already in PATH and writable without sudo.
+  local candidates=(
+    "$HOME/.local/bin"
+    "/opt/homebrew/bin"
+    "/usr/local/bin"
+  )
+
+  local dir
+  for dir in "${candidates[@]}"; do
+    if path_contains_dir "$dir"; then
+      if create_adal_shim "$dir"; then
+        echo -e "  ${GREEN}✅ Made adal available in current PATH via $dir${NC}"
+        return 0
+      elif [ "$?" -eq 2 ]; then
+        return 0
+      fi
+    fi
+  done
+
+  # Still create the user-local shim for future shells that include ~/.local/bin.
+  mkdir -p "$HOME/.local/bin"
+  create_adal_shim "$HOME/.local/bin" || true
+}
+
+# ┌─ Clean old versions ────────────────────────────────────────────────────────────
+
+cleanup_old_versions() {
+  local versions=()
+
+  # List version directories (exclude 'current' symlink and the just-installed version)
+  for dir in "$VERSIONS_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    local name
+    name=$(basename "$dir")
+    [ "$name" = "current" ] && continue
+    [ "$name" = "$VERSION" ] && continue
+    versions+=("$name")
+  done
+
+  # Remove all old versions (the current $VERSION is already excluded above)
+  if [ ${#versions[@]} -gt 0 ]; then
+    for ver in "${versions[@]}"; do
+      rm -rf "${VERSIONS_DIR:?}/$ver"
+    done
+  fi
+}
+
+# ┌─ PATH setup ────────────────────────────────────────────────────────────────
+
+add_to_path() {
+  local config_file="$1"
+  local command="$2"
+  local legacy_command="${command//\$HOME/$HOME}"
+
+  if grep -Fxq "$command" "$config_file" 2>/dev/null || \
+     grep -Fxq "$legacy_command" "$config_file" 2>/dev/null; then
+    return 0  # Already present
+  fi
+
+  if [ -w "$config_file" ]; then
+    echo "" >> "$config_file"
+    echo "$command" >> "$config_file"
+    echo -e "  ${GREEN}✅ Added AdaL to PATH in $config_file${NC}"
+  else
+    echo -e "  ${YELLOW}Manually add to $config_file:${NC}"
+    echo -e "    $command"
+  fi
+}
+
+setup_path() {
+  if [ "$no_modify_path" = true ]; then
+    return 0
+  fi
+
+  # Check if already in PATH
+  if [[ ":$PATH:" == *":$BIN_DIR:"* ]]; then
+    return 0
+  fi
+
+  local current_shell
+  current_shell=$(basename "${SHELL:-/bin/sh}")
+
+  local config_files=""
+  local default_config_file=""
+  case "$current_shell" in
+    fish)
+      config_files="$HOME/.config/fish/config.fish"
+      default_config_file="$HOME/.config/fish/config.fish"
+      ;;
+    zsh)
+      config_files="${ZDOTDIR:-$HOME}/.zshrc"
+      default_config_file="${ZDOTDIR:-$HOME}/.zshrc"
+      ;;
+    bash)
+      config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile"
+      default_config_file="$HOME/.bashrc"
+      ;;
+    ash|sh)
+      config_files="$HOME/.profile"
+      default_config_file="$HOME/.profile"
+      ;;
+    *)
+      config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile"
+      default_config_file="$HOME/.profile"
+      ;;
+  esac
+
+  # Find the first existing config file.
+  local config_file=""
+  for file in $config_files; do
+    if [ -f "$file" ]; then
+      config_file="$file"
+      break
+    fi
+  done
+
+  # Fresh machines may not have a shell config yet. Create the default one so
+  # future terminals can find AdaL without requiring manual PATH setup.
+  if [ -z "$config_file" ]; then
+    config_file="$default_config_file"
+    mkdir -p "$(dirname "$config_file")"
+    touch "$config_file"
+  fi
+
+  case "$current_shell" in
+    fish) add_to_path "$config_file" "fish_add_path \$HOME/.adal/bin" ;;
+    *)    add_to_path "$config_file" "export PATH=\"\$HOME/.adal/bin:\$PATH\"" ;;
+  esac
+}
+
+setup_github_actions_path() {
+  if [ -n "${GITHUB_ACTIONS:-}" ] && [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_PATH:-}" ]; then
+    if ! grep -qx "$BIN_DIR" "$GITHUB_PATH" 2>/dev/null; then
+      echo "$BIN_DIR" >> "$GITHUB_PATH"
+      echo -e "  ${GREEN}✅ Added to \$GITHUB_PATH${NC}"
+    fi
+  fi
+}
+
+# ┌─ Migration detection ────────────────────────────────────────────────────────────
+
+detect_npm_install() {
+  if command -v adal >/dev/null 2>&1; then
+    local existing_path
+    existing_path=$(which adal 2>/dev/null || command -v adal 2>/dev/null || true)
+    if [ -n "$existing_path" ] && [[ "$existing_path" != *".adal/bin"* ]]; then
+      # Silently note the npm install exists — don't suggest uninstalling
+      # because that can break 'adal' command if ~/.adal/bin isn't in PATH yet.
+      # Both coexist safely; native takes priority after terminal restart.
+      :
+    fi
+  fi
+}
+
+print_success() {
+  echo -e ""
+  echo -e "${GREEN}🌸 AdaL CLI v${VERSION} installed!${NC}"
+  echo -e ""
+  echo -e "${MUTED}Location: ${NC}$BIN_DIR/adal"
+  echo -e ""
+  echo -e "${MUTED}Next: Run ${NC}adal${MUTED} in your working directory${NC}"
+  echo -e ""
+}
+
+# ┌─ Anonymous install tracking (OPT-IN) ────────────────────────────────────────────
+
+# Fire-and-forget POST so we can count actual installs/upgrades.
+# Only called from install_version(), so same-version no-op reinstalls don't
+# fire (check_existing() exits earlier on that path).
+#
+# Default is OFF. Enabled by --track or ADAL_TRACK=1. Always overridable with
+# --no-track / ADAL_NO_TRACK=1.
+#
+# The payload is HMAC-SHA256 signed (X-Adal-Signature) with a timestamp and
+# nonce so the server can reject stale/replayed/naively-forged requests. The
+# secret is embedded in this public script — this is obfuscation, not auth;
+# the server must additionally rate-limit by IP/UA. See RELEASE.md.
+track_install() {
+  [ "$no_track" = true ] && return 0
+  if [ "${ADAL_TRACK:-0}" != "1" ] && [ "$track_opt_in" != true ]; then
+    return 0
+  fi
+  [ "${ADAL_NO_TRACK:-0}" = "1" ] && return 0
+  [ -z "$TRACK_URL" ] && return 0
+
+  # Two channels: "stable" = clean semver (X.Y.Z exactly), "beta" = anything else.
+  local channel="stable"
+  case "$VERSION" in
+    *-*) channel="beta" ;;
+  esac
+
+  # install vs upgrade — does any prior version dir exist?
+  local event_type="install"
+  if [ -d "$VERSIONS_DIR" ]; then
+    for dir in "$VERSIONS_DIR"/*/; do
+      [ -d "$dir" ] || continue
+      local name
+      name=$(basename "$dir")
+      [ "$name" = "current" ] && continue
+      [ "$name" = "$VERSION" ] && continue
+      event_type="upgrade"
+      break
+    done
+  fi
+
+  local ts nonce
+  ts=$(date +%s 2>/dev/null || echo 0)
+  nonce=$( (head -c 16 /dev/urandom 2>/dev/null || echo "random") | od -An -tx1 2>/dev/null | tr -d ' \n' | head -c 32)
+
+  local body="{\"platform\":\"cli\",\"channel\":\"$channel\",\"event_type\":\"$event_type\",\"version\":\"$VERSION\",\"ts\":\"$ts\",\"nonce\":\"$nonce\"}"
+
+  local sig=""
+  if command -v openssl >/dev/null 2>&1; then
+    sig=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$TRACK_HMAC_SECRET" 2>/dev/null | awk '{print $NF}')
+  elif command -v python3 >/dev/null 2>&1; then
+    sig=$(printf '%s' "$body" | python3 -c 'import sys,hmac,hashlib; print(hmac.new(sys.argv[1].encode(), sys.stdin.buffer.read(), hashlib.sha256).hexdigest())' "$TRACK_HMAC_SECRET" 2>/dev/null)
+  fi
+
+  (
+    if [ "$DOWNLOADER" = "curl" ]; then
+      curl -fsS -m 2 -X POST -H 'content-type: application/json' \
+        -H "X-Adal-Signature: $sig" -H "X-Adal-Ts: $ts" -H "X-Adal-Nonce: $nonce" \
+        -d "$body" "$TRACK_URL" >/dev/null 2>&1 || true
+    elif [ "$DOWNLOADER" = "wget" ]; then
+      wget -q -T 2 --header='content-type: application/json' \
+        --header="X-Adal-Signature: $sig" --header="X-Adal-Ts: $ts" --header="X-Adal-Nonce: $nonce" \
+        --post-data="$body" -O /dev/null "$TRACK_URL" >/dev/null 2>&1 || true
+    fi
+  ) &
+  disown 2>/dev/null || true
+}
+
+# ┌─ Main ───────────────────────────────────────────────────────────────────────────
+
+main() {
+  detect_platform
+  ensure_musl_runtime_deps
+
+  if [ -n "$local_tarball" ]; then
+    # Local tarball mode: skip download, version resolution, and checksum
+    install_from_local_tarball "$local_tarball"
+  else
+    detect_downloader
+    resolve_version
+    check_existing
+    install_version
+  fi
+
+  setup_symlinks
+  cleanup_old_versions
+  setup_path
+  setup_github_actions_path
+  detect_npm_install
+  print_success
+}
+
+main

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -52,7 +52,7 @@ done
 command -v minisign >/dev/null 2>&1 || { echo "minisign is required (brew install minisign / apt install minisign)" >&2; exit 1; }
 
 # Public key must match the one embedded in install.sh
-SIGNING_PUBLIC_KEY="RWTpQA9INHbbcb1MHIInAuhmJRnFaOn4Bf+Ye8oftDSkWK/SrYakIH3m"
+SIGNING_PUBLIC_KEY="RWSZUbVM/EZtFEz8cAk+0zEnPI2cCSQFuSuK4xp0KUlP+Wdf71tvUl7C"
 
 # Expand globs
 targets=()

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AdaL release signing script (minisign / Ed25519)
+#
+# Signs every release tarball and writes a detached <tarball>.minisig next to
+# it. The installer (install.sh) downloads <tarball>.minisig and verifies it
+# against the embedded public key.
+#
+# Usage:
+#   scripts/sign-release.sh \
+#     --version 1.5.7 \
+#     --key     /path/to/adal-release.minisign \
+#     --files   dist/adal-1.5.7-*.tar.gz dist/adal-1.5.7-*.zip
+#
+# Env:
+#   ADAL_SIGNING_KEY   alternative to --key
+#
+# The private key must NEVER be committed to a repo or embedded in the
+# installer. Store it in CI secrets / a secrets manager; the PUBLIC key lives
+# in install.sh as SIGNING_PUBLIC_KEY.
+
+usage() {
+  cat <<EOF
+Usage: sign-release.sh --version <VER> --key <PRIVATE_KEY> --files <GLOB...>
+
+Options:
+  --version <VER>    Release version (e.g. 1.5.7) — used only for output naming
+  --key <PATH>       Path to the minisign secret key (adal-release.minisign)
+  --files <GLOB...>  One or more globs matching the tarballs/zips to sign
+  --check            Only verify existing .minisig files against the public key
+  -h, --help         Show this help
+EOF
+}
+
+check=false
+version=""
+key_path="${ADAL_SIGNING_KEY:-}"
+files=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --check) check=true; shift ;;
+    --version) version="$2"; shift 2 ;;
+    --key) key_path="$2"; shift 2 ;;
+    --files) shift; files+=("$@"); break ;;
+    *) echo -e "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+command -v minisign >/dev/null 2>&1 || { echo "minisign is required (brew install minisign / apt install minisign)" >&2; exit 1; }
+
+# Public key must match the one embedded in install.sh
+SIGNING_PUBLIC_KEY="RWTpQA9INHbbcb1MHIInAuhmJRnFaOn4Bf+Ye8oftDSkWK/SrYakIH3m"
+
+# Expand globs
+targets=()
+for g in "${files[@]}"; do
+  for f in $g; do
+    [ -f "$f" ] && targets+=("$f")
+  done
+done
+[ ${#targets[@]} -gt 0 ] || { echo "No files matched the given globs" >&2; exit 1; }
+
+if [ "$check" = true ]; then
+  for f in "${targets[@]}"; do
+    echo "verify: $f"
+    minisign -Vm "$f" -P "$SIGNING_PUBLIC_KEY" -x "$f.minisig" || exit 1
+  done
+  echo "All signatures OK"
+  exit 0
+fi
+
+[ -n "$version" ] || { echo "--version is required" >&2; exit 1; }
+[ -n "$key_path" ] && [ -f "$key_path" ] || { echo "--key must point to an existing minisign secret key" >&2; exit 1; }
+
+for f in "${targets[@]}"; do
+  echo "sign:   $f"
+  minisign -S -s "$key_path" -m "$f" -x "$f.minisig"
+done
+
+echo ""
+echo "Done. Upload each <tarball>.minisig next to its tarball in S3:"
+echo "  s3://.../cli/<version>/adal-<version>-<platform>.tar.gz.minisig"
+echo ""
+echo "Public key (must match install.sh SIGNING_PUBLIC_KEY):"
+echo "  $SIGNING_PUBLIC_KEY"

--- a/tests/capture_server.py
+++ b/tests/capture_server.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Tiny HTTP capture server for installer E2E tests.
+
+Usage: capture_server.py <log_file> <port_file>
+Writes each POST's headers + body to <log_file> and its bound port to
+<port_file>, then returns 200. Exits when the log file contains a line
+beginning with "STOP" (written by the test) or on SIGTERM.
+"""
+import http.server
+import os
+import socketserver
+import sys
+
+log_file, port_file = sys.argv[1], sys.argv[2]
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        with open(log_file, "a") as f:
+            f.write("PATH: %s\n" % self.path)
+            for k, v in self.headers.items():
+                f.write("%s: %s\n" % (k, v))
+            f.write("BODY: %s\n" % body.decode("utf-8", "replace"))
+            f.write("---\n")
+        self.send_response(200)
+        self.end_headers()
+        if b"STOP" in body:
+            os._exit(0)
+
+    def log_message(self, *args):
+        pass
+
+
+with socketserver.TCPServer(("127.0.0.1", 0), Handler) as srv:
+    with open(port_file, "w") as f:
+        f.write(str(srv.server_address[1]))
+    srv.serve_forever()

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Shared helpers for the installer test suite.
+# Zero dependencies: plain bash, runs on macOS + Linux.
+
+PASS=0
+FAIL=0
+CURRENT_TEST=""
+
+t() { CURRENT_TEST="$1"; }
+
+ok() { PASS=$((PASS + 1)); echo "  ok  $CURRENT_TEST"; }
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL $CURRENT_TEST — $1" >&2
+  [ -n "${2:-}" ] && echo "       $2" >&2
+}
+
+assert_eq() { [ "$1" = "$2" ] && ok || fail "expected '$2', got '$1'"; }
+assert_contains() {
+  case "$1" in
+    *"$2"*) ok ;;
+    *) fail "output should contain '$2'" ; echo "$1" | sed 's/^/       | /' >&2 ;;
+  esac
+}
+assert_not_contains() {
+  case "$1" in
+    *"$2"*) fail "output should NOT contain '$2'" ; echo "$1" | sed 's/^/       | /' >&2 ;;
+    *) ok ;;
+  esac
+}
+assert_zero() { { [ -n "$1" ] && [ "$1" -eq 0 ]; } && ok || fail "expected exit 0, got '${1:-}'"; }
+assert_nonzero() { { [ -n "$1" ] && [ "$1" -ne 0 ]; } && ok || fail "expected non-zero exit, got '${1:-}'"; }
+assert_file() { [ -f "$1" ] && ok || fail "expected file $1 to exist"; }
+assert_exec() { [ -x "$1" ] && ok || fail "expected $1 to be executable"; }
+
+# Extract function bodies from install.sh (BSD-awk safe)
+extract_funcs() {
+  local src="$1"; shift
+  for fn in "$@"; do
+    awk -v fn="$fn" '
+      index($0, fn "()") > 0 && $0 ~ /\)[[:space:]]*\{/ { in_fn = 1 }
+      in_fn { print }
+      in_fn && $0 == "}" { in_fn = 0; print "" }
+    ' "$src"
+  done
+}
+
+# Exit non-zero if any test failed
+finish() {
+  echo ""
+  echo "  Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ] || exit 1
+  exit 0
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Test runner: executes every tests/test_*.sh and aggregates results.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+pass=0
+fail=0
+failed_files=()
+
+for t in "$HERE"/test_*.sh; do
+  echo "== $(basename "$t") =="
+  if bash "$t"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    failed_files+=("$(basename "$t")")
+  fi
+  echo ""
+done
+
+echo "======================================"
+echo "Suites: $pass passed, $fail failed"
+if [ ${#failed_files[@]} -gt 0 ]; then
+  printf 'Failed: %s\n' "${failed_files[*]}"
+  exit 1
+fi
+echo "All installer tests passed."
+exit 0

--- a/tests/test_install_e2e.sh
+++ b/tests/test_install_e2e.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# End-to-end installer tests against a local file:// release layout.
+#
+# These exercise the full download -> manifest-schema -> checksum ->
+# signature -> extract -> symlink pipeline, plus opt-in tracking with an
+# HMAC-signed payload captured by a local HTTP server.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/install.sh"
+
+# shellcheck disable=SC1091
+source "$(dirname "$0")/lib.sh"
+
+command -v minisign >/dev/null 2>&1 || { echo "SKIP: minisign not installed (brew install minisign)"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not installed"; exit 0; }
+
+WORK=$(mktemp -d)
+LAYOUT="$WORK/releases"
+SIGN="$WORK/sign"
+mkdir -p "$LAYOUT/manifests" "$LAYOUT/0.9.0" "$SIGN"
+
+VERSION="0.9.0"
+PLATFORM="darwin-arm64"
+ARCHIVE="adal-$VERSION-$PLATFORM.tar.gz"
+
+cleanup() { [ -n "${CAP_PID:-}" ] && kill "$CAP_PID" 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ---- helpers ---------------------------------------------------------------
+file_size() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then stat -f%z "$1"; else stat -c%s "$1"; fi
+}
+
+# Build the fake release payload (a tarball that would legitimately extract)
+build_payload() {
+  local payload_dir="$WORK/payload/adal-$VERSION"
+  rm -rf "$WORK/payload"
+  mkdir -p "$payload_dir"
+  echo 'console.log("adal stub")' > "$payload_dir/adal-cli.js"
+  cat > "$payload_dir/adal" <<'STUB'
+#!/usr/bin/env bash
+echo "adal test stub $VERSION"
+STUB
+  chmod +x "$payload_dir/adal"
+  tar -czf "$LAYOUT/$VERSION/$ARCHIVE" -C "$WORK/payload" "adal-$VERSION"
+}
+
+# Regenerate manifest from the current tarball (uses real checksum/size)
+write_manifest() {
+  local checksum
+  checksum=$(shasum -a 256 "$LAYOUT/$VERSION/$ARCHIVE" | cut -d' ' -f1)
+  local size
+  size=$(file_size "$LAYOUT/$VERSION/$ARCHIVE")
+  printf '{"version":"%s","channel":"latest","date":"2026-01-01T00:00:00Z","platforms":{"%s":{"filename":"%s","checksum":"%s","size":%s}}}\n' \
+    "$VERSION" "$PLATFORM" "$ARCHIVE" "$checksum" "$size" \
+    > "$LAYOUT/manifests/manifest-$VERSION.json"
+}
+
+# Generate a throwaway signing keypair and export the public key to the installer
+setup_signing() {
+  minisign -G -W -s "$SIGN/mini.key" -p "$SIGN/mini.pub" >/dev/null 2>&1
+  # The installer accepts ADAL_SIGNING_PUBLIC_KEY override so tests can use a
+  # throwaway key instead of the production one embedded in install.sh.
+  export ADAL_SIGNING_PUBLIC_KEY
+  ADAL_SIGNING_PUBLIC_KEY=$(tail -1 "$SIGN/mini.pub")
+}
+
+sign_archive() {
+  minisign -S -s "$SIGN/mini.key" -m "$LAYOUT/$VERSION/$ARCHIVE" -x "$LAYOUT/$VERSION/$ARCHIVE.minisig" >/dev/null 2>&1
+}
+
+# Run the installer with a FRESH home unless TEST_HOME is set.
+# EXTRA_ENV may carry additional KEY=VAL pairs.
+run_install() {
+  local home_dir="${TEST_HOME:-$WORK/home-$$-$RANDOM}"
+  mkdir -p "$home_dir"
+  # shellcheck disable=SC2086
+  env HOME="$home_dir" ADAL_RELEASES_URL="file://$LAYOUT" ADAL_TRACK_URL="${TRACK_URL:-}" ${EXTRA_ENV:-} \
+    bash "$SRC" --no-modify-path "$@" 2>&1
+  echo "EXIT_CODE:$?"
+}
+
+exit_code_of() { echo "$1" | sed -n 's/^EXIT_CODE:\([0-9]*\)$/\1/p' | tail -1; }
+
+assert_exit() { # expected_code, output
+  local code
+  code=$(exit_code_of "$2")
+  if [ "$code" = "$1" ]; then ok; else fail "expected exit $1, got $code"; echo "$2" | sed 's/^/       | /' | tail -25 >&2; fi
+}
+
+# ---- fixture setup ---------------------------------------------------------
+setup_signing
+build_payload
+write_manifest
+sign_archive
+echo -n "$VERSION" > "$LAYOUT/latest"
+echo -n "$VERSION" > "$LAYOUT/beta"
+
+echo "== happy path: signed release installs =="
+t "install v$VERSION with valid signature + checksum"
+H="$WORK/happy-home"; mkdir -p "$H"
+OUT=$(TEST_HOME="$H" run_install --version "$VERSION" --no-track)
+assert_exit 0 "$OUT"
+assert_contains "$OUT" "Ed25519 signature verified"
+assert_file "$H/.adal/bin/adal"
+assert_exec "$H/.adal/versions/$VERSION/adal"
+assert_file "$H/.adal/versions/$VERSION/adal-cli.js"
+
+t "reinstall (already installed) is a no-op success"
+OUT=$(TEST_HOME="$H" run_install --version "$VERSION" --no-track)
+assert_exit 0 "$OUT"
+assert_contains "$OUT" "already installed"
+
+echo ""
+echo "== tamper detection =="
+
+t "tampered tarball -> integrity check fails"
+printf 'X' >> "$LAYOUT/$VERSION/$ARCHIVE"
+OUT=$(run_install --version "$VERSION" --no-track)
+assert_nonzero "$(exit_code_of "$OUT")"
+# Size check fires before checksum; either message is the correct protection
+assert_contains "$OUT" "Error:"
+assert_not_contains "$OUT" "installed!"
+build_payload && write_manifest && sign_archive
+
+t "tampered tarball + forged manifest checksum -> signature fails"
+printf 'X' >> "$LAYOUT/$VERSION/$ARCHIVE"
+write_manifest   # manifest now matches the tampered file, but the .minisig does not
+OUT=$(run_install --version "$VERSION" --no-track)
+assert_nonzero "$(exit_code_of "$OUT")"
+assert_contains "$OUT" "Signature verification failed"
+build_payload && write_manifest && sign_archive
+
+echo ""
+echo "== signature availability modes =="
+
+t "missing .minisig -> transition warning, install proceeds"
+rm -f "$LAYOUT/$VERSION/$ARCHIVE.minisig"
+OUT=$(run_install --version "$VERSION" --no-track)
+assert_exit 0 "$OUT"
+assert_contains "$OUT" "No signature published"
+sign_archive
+
+t "missing .minisig + ADAL_REQUIRE_SIGNATURE=1 -> hard fail"
+rm -f "$LAYOUT/$VERSION/$ARCHIVE.minisig"
+OUT=$(EXTRA_ENV="ADAL_REQUIRE_SIGNATURE=1" run_install --version "$VERSION" --no-track)
+assert_nonzero "$(exit_code_of "$OUT")"
+assert_contains "$OUT" "Signature file missing"
+sign_archive
+
+echo ""
+echo "== manifest schema validation =="
+
+t "malformed manifest (missing checksum) -> hard fail"
+printf '{"version":"%s","platforms":{"%s":{"filename":"%s","size":123}}}\n' "$VERSION" "$PLATFORM" "$ARCHIVE" \
+  > "$LAYOUT/manifests/manifest-$VERSION.json"
+OUT=$(run_install --version "$VERSION" --no-track)
+assert_nonzero "$(exit_code_of "$OUT")"
+assert_contains "$OUT" "checksum"
+write_manifest
+
+t "manifest with wrong filename -> hard fail"
+printf '{"version":"%s","platforms":{"%s":{"filename":"evil.tar.gz","checksum":"%064d","size":1}}}\n' "$VERSION" "$PLATFORM" 0 \
+  > "$LAYOUT/manifests/manifest-$VERSION.json"
+OUT=$(run_install --version "$VERSION" --no-track)
+assert_nonzero "$(exit_code_of "$OUT")"
+assert_contains "$OUT" "does not match expected"
+write_manifest
+
+echo ""
+echo "== version resolution =="
+
+t "channel resolution (--version beta) installs resolved version"
+OUT=$(run_install --version beta --no-track)
+assert_exit 0 "$OUT"
+assert_contains "$OUT" "Resolving channel 'beta'"
+
+t "latest resolution (no --version) installs latest"
+OUT=$(run_install --no-track)
+assert_exit 0 "$OUT"
+assert_contains "$OUT" "Checking for latest version"
+
+t "invalid version string rejected"
+OUT=$(run_install --version "../etc/passwd" --no-track)
+assert_nonzero "$(exit_code_of "$OUT")"
+assert_contains "$OUT" "Invalid version format"
+
+echo ""
+echo "== tracking (opt-in + HMAC) =="
+
+TRACK_LOG="$WORK/captured.log"
+PORT_FILE="$WORK/port"
+python3 "$ROOT/tests/capture_server.py" "$TRACK_LOG" "$PORT_FILE" >/dev/null 2>&1 &
+CAP_PID=$!
+for _ in $(seq 1 50); do [ -s "$PORT_FILE" ] && break; sleep 0.1; done
+TRACK_URL="http://127.0.0.1:$(cat "$PORT_FILE")/api/installs/track"
+export TRACK_URL
+
+t "default: tracking OFF — no request is sent"
+OUT=$(run_install --version "$VERSION")
+assert_exit 0 "$OUT"
+sleep 1
+[ -s "$TRACK_LOG" ] && fail "tracking request was sent despite opt-in default" || ok
+
+t "--track: POST sent with HMAC signature + ts + nonce"
+OUT=$(run_install --version "$VERSION" --track)
+assert_exit 0 "$OUT"
+sleep 1
+assert_file "$TRACK_LOG"
+LOG=$(cat "$TRACK_LOG")
+assert_contains "$LOG" "X-Adal-Signature:"
+assert_contains "$LOG" "X-Adal-Ts:"
+assert_contains "$LOG" "X-Adal-Nonce:"
+assert_contains "$LOG" '"channel":"stable"'
+
+t "HMAC-SHA256 signature matches body (computed independently)"
+BODY=$(grep '^BODY:' "$TRACK_LOG" | tail -1 | sed 's/^BODY: //')
+SIG=$(grep '^X-Adal-Signature:' "$TRACK_LOG" | tail -1 | cut -d' ' -f2)
+EXPECTED=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "adal-cli-install-track-v1" 2>/dev/null | awk '{print $NF}')
+assert_eq "$SIG" "$EXPECTED"
+
+t "--no-track overrides ADAL_TRACK=1"
+: > "$TRACK_LOG"
+OUT=$(EXTRA_ENV="ADAL_TRACK=1" run_install --version "$VERSION" --no-track)
+sleep 1
+[ -s "$TRACK_LOG" ] && fail "request sent despite --no-track" || ok
+
+kill "$CAP_PID" 2>/dev/null
+CAP_PID=""
+
+finish

--- a/tests/test_parsing.sh
+++ b/tests/test_parsing.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Unit tests for the parsing/validation helpers in install.sh
+set -u
+SRC="${SRC:-$(cd "$(dirname "$0")/.." && pwd)/install.sh}"
+
+# shellcheck disable=SC1091
+source "$(dirname "$0")/lib.sh"
+
+eval "$(extract_funcs "$SRC" json_get json_get_num json_get_platform validate_version)"
+
+echo "== json_get / json_get_num / json_get_platform =="
+
+t "json_get string value"
+assert_eq "$(json_get '{"a":"b"}' "a")" "b"
+
+t "json_get missing key is empty"
+assert_eq "$(json_get '{"a":"b"}' "nope")" ""
+
+t "json_get_num numeric value"
+assert_eq "$(json_get_num '{"n":42}' "n")" "42"
+
+t "json_get_platform nested under platforms key (real manifest shape)"
+assert_contains "$(json_get_platform '{"version":"1.2.3","platforms":{"darwin-arm64":{"checksum":"abc","size":1}}}' "darwin-arm64")" '"checksum":"abc"'
+
+t "json_get_platform top-level placement"
+assert_contains "$(json_get_platform '{"linux-x64":{"checksum":"xyz","size":2}}' "linux-x64")" '"checksum":"xyz"'
+
+t "json_get_platform missing platform is empty"
+assert_eq "$(json_get_platform '{"version":"1"}' "win32-x64")" ""
+
+t "json_get_platform ignores nested false-positive keys"
+# A value that merely CONTAINS the platform name must not be extracted as a block
+assert_eq "$(json_get_platform '{"note":"darwin-arm64 is neat"}' "darwin-arm64")" ""
+
+echo ""
+echo "== validate_version =="
+
+t "accepts plain semver"
+validate_version "1.2.3" && ok || fail "1.2.3 should pass"
+
+t "accepts beta suffix"
+validate_version "1.2.3-beta.1" && ok || fail "1.2.3-beta.1 should pass"
+
+t "accepts rc suffix"
+validate_version "1.2.3-rc.2" && ok || fail "1.2.3-rc.2 should pass"
+
+t "rejects path traversal"
+(validate_version "1.2.3/../../etc" 2>/dev/null) && fail "traversal accepted" || ok
+
+t "rejects double dot in suffix"
+(validate_version "1.2.3-beta..1" 2>/dev/null) && fail "double-dot accepted" || ok
+
+t "rejects incomplete version"
+(validate_version "1.2" 2>/dev/null) && fail "1.2 accepted" || ok
+
+t "rejects v prefix"
+(validate_version "v1.2.3" 2>/dev/null) && fail "v-prefix accepted" || ok
+
+t "rejects empty version"
+(validate_version "" 2>/dev/null) && fail "empty accepted" || ok
+
+echo ""
+echo "== tarball filename validation =="
+
+validate_tarball_name() {
+  [[ "$1" =~ ^adal-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?-(darwin|linux|win32)-(x64|arm64)(-musl)?\.(tar\.gz|zip)$ ]]
+}
+
+t "accepts darwin arm64 tarball"
+validate_tarball_name "adal-1.5.7-darwin-arm64.tar.gz" && ok || fail "should accept"
+
+t "accepts musl tarball"
+validate_tarball_name "adal-0.6.0-beta.1-linux-x64-musl.tar.gz" && ok || fail "should accept"
+
+t "accepts win32 zip"
+validate_tarball_name "adal-1.2.3-win32-x64.zip" && ok || fail "should accept"
+
+t "rejects command substitution in filename"
+validate_tarball_name 'adal-1.0.0-$(reboot)-linux-x64.tar.gz' && fail "injection accepted" || ok
+
+t "rejects path traversal in filename"
+validate_tarball_name 'adal-1.2.3-../../etc-linux-x64.tar.gz' && fail "traversal accepted" || ok
+
+t "rejects unsupported platform segment"
+validate_tarball_name "adal-1.2.3-FREEBSD-x64.tar.gz" && fail "unsupported OS accepted" || ok
+
+t "rejects missing version"
+validate_tarball_name "adal--linux-x64.tar.gz" && fail "missing version accepted" || ok
+
+finish


### PR DESCRIPTION
## Summary

Security hardening of the `curl | bash` installer, based on a full differential audit of the script currently deployed at `adal.sylph.ai/install.sh`. The hardened installer is a complete, tested replacement at `install.sh`, with release-side tooling, a test suite, and runbooks.

**Key changes**

- **Ed25519 signature verification (minisign)** — every downloaded tarball is verified against a detached `<tarball>.minisig` using a public key embedded in the installer. Enforced whenever a signature is published; `ADAL_REQUIRE_SIGNATURE=1` makes a missing signature/minisign a hard failure. Transition mode warns while the pipeline is not yet publishing `.minisig` files.
- **Manifest schema validation** — `version`, `platforms.<platform>.filename/checksum/size` are validated before anything is trusted; malformed manifests are refused, never silently trusted.
- **Robust JSON parsing** — `jq` → `python3` → `sed` fallback. The old sed-only parser extracted the nested `platforms` key only by accident; a manifest format change would have silently disabled checksum verification.
- **Strict semver + tarball filename validation** — blocks command injection / path traversal via `--version` and `--local-tarball` names.
- **Hard failure when manifest/checksum is unavailable** (no silent skip).
- **EXIT trap** cleans the temp dir on error/signal; extraction is verified via the real entry point (`adal` executable / `adal.cmd`).
- **Tracking is now opt-in** (`--track` / `ADAL_TRACK=1`); requests carry an HMAC-SHA256 signature + timestamp + nonce (server-side verification reference in RELEASE.md).
- Actionable error message for the unpublished `linux-arm64-musl` platform.
- Fixed `2>/devuhl` typo → `2>/dev/null`.

**New files**

| Path | Purpose |
|---|---|
| `install.sh` | Hardened installer (replaces the deployed script) |
| `scripts/sign-release.sh` | Release-side signing (`--check` mode included) |
| `tests/` | Zero-dependency test suite: unit parsing tests + full E2E (tamper, forged manifest, signature modes, schema violations, channel resolution, HMAC tracking) |
| `SECURITY.md` | Threat model, key custody/rotation, accepted limitations, org-side actions |
| `RELEASE.md` | Deploy + signing runbook, manifest schema, HMAC endpoint reference, musl CI matrix |

**Testing** — `bash tests/run.sh`: 2 suites, all passing. `shellcheck --severity=warning`: clean. E2E builds a fake signed release served over `file://` and proves: happy path with signature verified, tampered tarball rejected (size+checksum), forged-manifest attack caught by the signature, missing-signature transition mode, `ADAL_REQUIRE_SIGNATURE=1` hard fail, schema violations refused, and the opt-in tracking POST with a valid HMAC captured by a local HTTP server.

**Not included in this PR (needs `workflow` scope / org access)** — CI workflow; see below.

## CI workflow (for `.github/workflows/ci.yml`)

```yaml
name: CI

on:
  push:
    branches: [main]
    paths: ['install.sh', 'scripts/**', 'tests/**']
  pull_request:
    paths: ['install.sh', 'scripts/**', 'tests/**']
  workflow_dispatch:

jobs:
  shellcheck:
    name: Shellcheck
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Install shellcheck
        run: sudo apt-get update && sudo apt-get install -y shellcheck
      - name: Lint
        run: |
          shellcheck --shell=bash --severity=style install.sh
          shellcheck scripts/sign-release.sh
          shellcheck tests/*.sh

  tests:
    name: Installer tests (${{ matrix.os }})
    strategy:
      fail-fast: false
      matrix:
        os: [ubuntu-latest, macos-latest]
    runs-on: ${{ matrix.os }}
    steps:
      - uses: actions/checkout@v4
      - name: Install minisign
        if: runner.os == 'Linux'
        run: sudo apt-get update && sudo apt-get install -y minisign
      - name: Install minisign
        if: runner.os == 'macOS'
        run: brew install minisign
      - name: Syntax check
        run: bash -n install.sh && bash -n scripts/sign-release.sh
      - name: Run test suite
        run: bash tests/run.sh
```

## Org-side follow-ups (details in SECURITY.md / RELEASE.md)

1. Deploy `install.sh` to `adal.sylph.ai/install.sh` (this repo is the community home; the live script is built from a private pipeline).
2. Publish `.minisig` files for every artifact via `scripts/sign-release.sh`; move the release signing key into CI secrets.
3. Add `linux-arm64-musl` to the release matrix (or stop advertising it).
4. Add HMAC + timestamp + rate-limit validation to the tracking endpoint (reference in RELEASE.md).
5. After ≥2 signed releases, flip missing-signature from warning to hard failure.
