### PR TITLE
feat: add hackathon presentation page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ AdaL CLI is a terminal-native platform for orchestrating AI agents, models, and 
 
 **This repository is the community home for AdaL CLI** — report issues, share what you build, and contribute skills.
 
+### Hackathon presentation
+
+Open the [`@skills:` system card](https://sylphai-inc.github.io/adal-cli/hackathon/) for a presentation-ready overview of reusable agent knowledge, skill delivery, and the two main workflows.
+
+Presenter notes and local preview instructions are in [`hackathon/README.md`](hackathon/README.md).
+
 ### Install AdaL CLI
 
 Native install is recommended: it manages AdaL's runtime and updates consistently across platforms.

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -1,0 +1,41 @@
+# @skills Hackathon Presentation
+
+Presentation page for the `@skills:` protocol and `atskills.one`.
+
+## Public page
+
+After the Pages workflow is merged and enabled:
+
+<https://sylphai-inc.github.io/adal-cli/hackathon/>
+
+## Present locally
+
+From the repository root:
+
+```bash
+python3 -m http.server 4173
+```
+
+Open:
+
+<http://127.0.0.1:4173/hackathon/>
+
+## Presentation flow
+
+1. Start with the outcome: an agent should not start recurring work from zero.
+2. Explain the system diagram from right to left:
+   - Team, GitHub, hub-managed, and curated skills
+   - `atskills.one` for discovery and management
+   - Portable `SKILL.md`
+   - Reference, save, auto-load, and `/skills`
+3. Walk through the two handbook journeys:
+   - Use an existing skill
+   - Turn a successful first pass into a reusable skill
+
+## Source
+
+The presentation is a self-contained HTML page:
+
+- `hackathon/index.html`
+
+Edit the HTML directly, then preview it with the local server before pushing changes.

--- a/hackathon/index.html
+++ b/hackathon/index.html
@@ -1,0 +1,653 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>@skills: system card</title>
+  <style>
+    @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Poppins:wght@300;400;500&display=swap");
+
+    :root {
+      --paper: #f0efe9;
+      --ink: #171715;
+      --line: #74726c;
+      --hairline: #9c9a93;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      width: 1536px;
+      height: 1791px;
+      margin: 0;
+      overflow: auto;
+    }
+
+    body {
+      color: var(--ink);
+      background:
+        repeating-linear-gradient(
+          0deg,
+          rgba(20, 20, 18, 0.018) 0,
+          rgba(20, 20, 18, 0.018) 1px,
+          transparent 1px,
+          transparent 4px
+        ),
+        var(--paper);
+      font-family: "Inter", Arial, Helvetica, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: geometricPrecision;
+    }
+
+    .mono,
+    .label,
+    code {
+      font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+    }
+
+    .page {
+      width: 100%;
+      height: 100%;
+    }
+
+    .file-bar {
+      height: 58px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 0 60px;
+      border-bottom: 1.5px solid var(--hairline);
+    }
+
+    .dot {
+      width: 9px;
+      height: 9px;
+      border: 1.4px solid var(--ink);
+      border-radius: 50%;
+    }
+
+    .dot:first-child {
+      background: var(--ink);
+    }
+
+    .file-icon {
+      width: 13px;
+      height: 17px;
+      margin-left: 10px;
+      border: 1.3px solid var(--ink);
+      position: relative;
+    }
+
+    .file-icon::after {
+      content: "";
+      position: absolute;
+      top: -1.3px;
+      right: -1.3px;
+      width: 6px;
+      height: 6px;
+      background: var(--paper);
+      border-left: 1.3px solid var(--ink);
+      border-bottom: 1.3px solid var(--ink);
+    }
+
+    .file-name {
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 1.8px;
+    }
+
+    .hero {
+      height: 290px;
+      display: grid;
+      grid-template-columns: minmax(0, 2.32fr) minmax(320px, 0.88fr);
+      gap: 42px;
+      padding: 34px 60px 28px;
+    }
+
+    .hero-copy {
+      min-width: 0;
+    }
+
+    .label {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 700;
+      line-height: 1;
+      letter-spacing: 3px;
+    }
+
+    h1 {
+      max-width: 960px;
+      margin: 0 0 17px;
+      font-family: "Poppins", "Inter", sans-serif;
+      font-size: 96px;
+      font-weight: 400;
+      line-height: 0.97;
+      letter-spacing: -0.052em;
+    }
+
+    .dek {
+      margin: 0;
+      font-size: 24px;
+      line-height: 1.35;
+      letter-spacing: -0.018em;
+    }
+
+    .summary {
+      padding-left: 34px;
+      border-left: 1.5px solid var(--line);
+    }
+
+    .summary-title {
+      padding: 2px 0 18px;
+      border-bottom: 1.5px solid var(--hairline);
+    }
+
+    .summary-row {
+      height: 52px;
+      display: flex;
+      align-items: center;
+      border-bottom: 1.5px solid var(--hairline);
+      font-size: 21px;
+      font-weight: 500;
+    }
+
+    .anatomy {
+      height: 680px;
+      margin: 0 60px;
+      border: 1.6px solid var(--line);
+      border-radius: 5px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .anatomy-head {
+      height: 58px;
+      display: flex;
+      align-items: center;
+      padding: 0 26px;
+    }
+
+    .diagram {
+      position: relative;
+      width: 100%;
+      height: 622px;
+    }
+
+    .connector-layer {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+    }
+
+    .connector-layer line,
+    .connector-layer path {
+      fill: none;
+      stroke: var(--line);
+      stroke-width: 2;
+    }
+
+    .connector-layer .active {
+      stroke: var(--ink);
+      stroke-width: 2.8;
+    }
+
+    .node {
+      position: absolute;
+      display: flex;
+      align-items: center;
+      min-height: 76px;
+      padding: 16px 18px;
+      border: 1.5px solid var(--line);
+      border-radius: 4px;
+      background: rgba(240, 239, 233, 0.94);
+      font-size: 19px;
+      font-weight: 500;
+    }
+
+    .node strong {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 23px;
+      line-height: 1.05;
+    }
+
+    .node code,
+    .node small {
+      display: block;
+      font-size: 17px;
+      line-height: 1.35;
+    }
+
+    .node-icon {
+      flex: 0 0 22px;
+      width: 22px;
+      height: 27px;
+      margin-right: 14px;
+      border: 1.4px solid var(--ink);
+      position: relative;
+    }
+
+    .node-icon::after {
+      content: "";
+      position: absolute;
+      top: -1.4px;
+      right: -1.4px;
+      width: 8px;
+      height: 8px;
+      background: var(--paper);
+      border-left: 1.4px solid var(--ink);
+      border-bottom: 1.4px solid var(--ink);
+    }
+
+    .source-icon {
+      width: 25px;
+      height: 25px;
+      flex: 0 0 25px;
+      margin-right: 14px;
+      color: var(--ink);
+    }
+
+    .source-icon * {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.7;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .reference { left: 48px; top: 35px; width: 286px; min-height: 92px; }
+    .save { left: 24px; top: 185px; width: 286px; min-height: 92px; }
+    .auto-trigger { left: 48px; top: 335px; width: 286px; min-height: 92px; }
+    .manage { left: 112px; top: 485px; width: 260px; min-height: 92px; }
+
+    .your-skills { left: 1120px; top: 15px; width: 250px; min-height: 86px; }
+    .team-project-skills { left: 1120px; top: 130px; width: 250px; min-height: 86px; }
+    .github-hosted { left: 1120px; top: 245px; width: 250px; min-height: 86px; }
+    .hub-managed { left: 1120px; top: 360px; width: 250px; min-height: 86px; }
+    .curated { left: 1120px; top: 475px; width: 250px; min-height: 86px; }
+
+    .knowledge-root,
+    .agent-root {
+      position: absolute;
+      top: 237px;
+      width: 184px;
+      height: 148px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      border: 1.8px solid var(--ink);
+      border-radius: 3px;
+      background: var(--paper);
+      text-align: center;
+    }
+
+    .knowledge-root { left: 780px; }
+    .agent-root { left: 414px; }
+
+    .knowledge-root::before,
+    .agent-root::before {
+      content: "";
+      position: absolute;
+      left: -1.8px;
+      top: -24px;
+      width: 72px;
+      height: 24px;
+      border: 1.8px solid var(--ink);
+      border-bottom: 0;
+      border-radius: 3px 3px 0 0;
+      background: var(--paper);
+    }
+
+    .knowledge-root strong { font-size: 24px; }
+    .knowledge-root small {
+      margin-top: 10px;
+      font-size: 17px;
+    }
+
+    .agent-root strong { font-size: 27px; }
+    .agent-root small {
+      margin-top: 10px;
+      font-size: 17px;
+    }
+
+    .skill {
+      position: absolute;
+      left: 626px;
+      top: 255px;
+      width: 126px;
+      height: 112px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      border: 1.5px solid var(--ink);
+      background: var(--paper);
+      text-align: center;
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+    .skill::before {
+      content: "";
+      position: absolute;
+      left: -1.5px;
+      top: -18px;
+      width: 40px;
+      height: 18px;
+      border: 1.5px solid var(--ink);
+      border-bottom: 0;
+      background: var(--paper);
+    }
+
+    .skill small {
+      max-width: 100px;
+      margin-top: 9px;
+      font-family: "Inter", sans-serif;
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 1.3;
+    }
+
+    .works {
+      height: 763px;
+      padding: 30px 60px 0;
+    }
+
+    .works-grid {
+      height: 663px;
+      display: grid;
+      grid-template-rows: repeat(2, 1fr);
+      border-bottom: 1.5px solid var(--line);
+    }
+
+    .work {
+      padding: 0;
+      border-bottom: 1.5px solid var(--hairline);
+    }
+
+    .work:last-child {
+      border-bottom: 0;
+    }
+
+    .work-header {
+      padding: 16px 28px 14px;
+    }
+
+    .work h3 {
+      margin: 0 0 8px;
+      font-family: "Inter", sans-serif;
+      font-size: 26px;
+      font-weight: 600;
+      line-height: 1.2;
+      letter-spacing: -0.02em;
+    }
+
+    .scenario-result {
+      margin: 0 0 16px;
+      font-size: 19px;
+      font-weight: 500;
+      line-height: 1.35;
+    }
+
+    .journey {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 14px;
+      margin: 0;
+      padding: 14px 28px 0;
+      border-top: 1.5px solid var(--line);
+      list-style: none;
+    }
+
+    .journey li {
+      min-width: 0;
+      padding-right: 12px;
+      border-right: 1px solid var(--hairline);
+    }
+
+    .journey li:last-child {
+      padding-right: 0;
+      border-right: 0;
+    }
+
+    .step-number {
+      display: block;
+      margin-bottom: 7px;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .step-action {
+      display: block;
+      margin-bottom: 5px;
+      font-size: 20px;
+      font-weight: 600;
+      line-height: 1.2;
+    }
+
+    .step-detail {
+      display: block;
+      font-size: 17px;
+      line-height: 1.32;
+    }
+
+    .step-command {
+      display: inline-block;
+      margin-bottom: 5px;
+      padding: 3px 5px;
+      border: 1px solid var(--hairline);
+      border-radius: 2px;
+      background: rgba(217, 215, 207, 0.42);
+      font-family: "JetBrains Mono", monospace;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.2;
+      white-space: nowrap;
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="file-bar">
+      <span class="dot"></span>
+      <span class="dot"></span>
+      <span class="dot"></span>
+      <span class="file-icon" aria-hidden="true"></span>
+      <span class="file-name mono">atskills.one</span>
+    </header>
+
+    <section class="hero">
+      <div class="hero-copy">
+        <h1>Your agent never<br>starts from zero.</h1>
+        <p class="dek">Give your agent direct access to reusable knowledge.</p>
+      </div>
+
+      <aside class="summary">
+        <p class="label summary-title">THE SYSTEM</p>
+        <div class="summary-row">@skills: lifecycle</div>
+        <div class="summary-row">atskills.one hub</div>
+        <div class="summary-row">Team + world knowledge</div>
+      </aside>
+    </section>
+
+    <section class="anatomy">
+      <header class="anatomy-head">
+        <h2 class="label">FROM SKILL CHAOS → CLARITY</h2>
+      </header>
+
+      <div class="diagram">
+        <svg class="connector-layer" viewBox="0 0 1416 622" preserveAspectRatio="none" aria-hidden="true">
+          <line x1="334" y1="81" x2="414" y2="280"/>
+          <line x1="310" y1="231" x2="414" y2="300"/>
+          <line x1="334" y1="381" x2="414" y2="321"/>
+          <line x1="372" y1="531" x2="414" y2="342"/>
+
+          <line class="active" x1="598" y1="311" x2="626" y2="311"/>
+          <line class="active" x1="752" y1="311" x2="780" y2="311"/>
+
+          <line x1="964" y1="270" x2="1120" y2="58"/>
+          <line x1="964" y1="290" x2="1120" y2="173"/>
+          <line x1="964" y1="311" x2="1120" y2="288"/>
+          <line x1="964" y1="332" x2="1120" y2="403"/>
+          <line x1="964" y1="352" x2="1120" y2="518"/>
+        </svg>
+
+        <div class="node reference">
+          <span class="node-icon"></span>
+          <div><strong>Reference</strong><code>@skills:&lt;path&gt;</code><small>Use for this task</small></div>
+        </div>
+
+        <div class="node save">
+          <span class="node-icon"></span>
+          <div><strong>Save</strong><code>@skills:&lt;path&gt;:save</code><small>Project owns it</small></div>
+        </div>
+
+        <div class="node auto-trigger">
+          <span class="node-icon"></span>
+          <div><strong>Auto-trigger</strong><code>@skills:&lt;path&gt;:install</code><small>Load automatically</small></div>
+        </div>
+
+        <div class="node manage">
+          <span class="node-icon"></span>
+          <div><strong>Manage</strong><code>/skills</code><small>Source + prompt cost</small></div>
+        </div>
+
+        <div class="agent-root">
+          <strong>agent/</strong>
+          <small>current task</small>
+        </div>
+
+        <div class="skill mono">SKILL.md<small>open · portable<br>versionable</small></div>
+
+        <div class="knowledge-root">
+          <strong>atskills.one</strong>
+          <small>discover + manage</small>
+        </div>
+
+        <div class="node your-skills">
+          <svg class="source-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="8" r="3"/>
+            <path d="M6.5 19c.7-3.2 2.5-5 5.5-5s4.8 1.8 5.5 5"/>
+          </svg>
+          <div><strong>Your skills</strong><small>Knowledge you create</small></div>
+        </div>
+
+        <div class="node team-project-skills">
+          <svg class="source-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="9" cy="8" r="2.5"/>
+            <circle cx="16" cy="9" r="2"/>
+            <path d="M4.5 18c.5-3 2-4.5 4.5-4.5s4 1.5 4.5 4.5"/>
+            <path d="M13 14.5c2.8-.8 5 .5 5.8 3.5"/>
+          </svg>
+          <div><strong>Team / project</strong><small>Shared procedures</small></div>
+        </div>
+
+        <div class="node github-hosted">
+          <svg class="source-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="7" cy="6" r="2"/>
+            <circle cx="17" cy="6" r="2"/>
+            <circle cx="12" cy="18" r="2"/>
+            <path d="M7 8v3c0 2 1.5 3 5 3v2"/>
+            <path d="M17 8v3c0 2-1.5 3-5 3"/>
+          </svg>
+          <div><strong>GitHub-hosted</strong><small>Open repositories</small></div>
+        </div>
+
+        <div class="node hub-managed">
+          <svg class="source-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M5 8.5 12 4l7 4.5v7L12 20l-7-4.5z"/>
+            <path d="m5 8.5 7 4.5 7-4.5"/>
+            <path d="M12 13v7"/>
+          </svg>
+          <div><strong>Hub-managed</strong><small>Published on atskills.one</small></div>
+        </div>
+
+        <div class="node curated">
+          <svg class="source-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M7 5h12M7 12h12M7 19h12"/>
+            <path d="m3.5 5 1 1 2-2M3.5 12l1 1 2-2M3.5 19l1 1 2-2"/>
+          </svg>
+          <div><strong>Curated lists</strong><small>Trusted collections</small></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="works">
+      <div class="works-grid">
+        <article class="work">
+          <div class="work-header">
+            <h3>Use an existing skill</h3>
+            <p class="scenario-result">Use skills without installing them to avoid bloating the system prompt.</p>
+          </div>
+          <ol class="journey">
+            <li>
+              <span class="step-number">01</span>
+              <span class="step-action">Choose a source</span>
+              <span class="step-detail">GitHub <code>gh:</code> or the <code>hub:</code> on atskills.one.</span>
+            </li>
+            <li>
+              <span class="step-number">02</span>
+              <span class="step-action">Use once</span>
+              <span class="step-command">@skills:&lt;path&gt;</span>
+              <span class="step-detail">For example, <code>gh:owner/repo</code> or <code>hub:creator/skill</code>.</span>
+            </li>
+            <li>
+              <span class="step-number">03</span>
+              <span class="step-action">Save</span>
+              <span class="step-command">@skills:&lt;path&gt;:save</span>
+              <span class="step-detail">Keep it in the project.</span>
+            </li>
+            <li>
+              <span class="step-number">04</span>
+              <span class="step-action">Auto-load</span>
+              <span class="step-command">@skills:&lt;path&gt;:install</span>
+              <span class="step-detail">Or configure it through <code>/skills</code> in AdaL.</span>
+            </li>
+          </ol>
+        </article>
+
+        <article class="work">
+          <div class="work-header">
+            <h3>Turn an expensive first pass into a reusable skill</h3>
+            <p class="scenario-result">Stop repeating completed work and reuse the same playbook across projects and agents.</p>
+          </div>
+          <ol class="journey">
+            <li>
+              <span class="step-number">01</span>
+              <span class="step-action">Capture</span>
+              <span class="step-command">SKILL.md</span>
+              <span class="step-detail">Write down the working process.</span>
+            </li>
+            <li>
+              <span class="step-number">02</span>
+              <span class="step-action">Store</span>
+              <span class="step-command">.atskills/ or hub:</span>
+              <span class="step-detail">Keep it in the project or publish it to the hub.</span>
+            </li>
+            <li>
+              <span class="step-number">03</span>
+              <span class="step-action">Share</span>
+              <span class="step-command">@skills:&lt;path&gt;</span>
+              <span class="step-detail">Give one path to the team.</span>
+            </li>
+            <li>
+              <span class="step-number">04</span>
+              <span class="step-action">Manage</span>
+              <span class="step-command">/skills · atskills.one</span>
+              <span class="step-detail">Use the AdaL CLI or the skills dashboard.</span>
+            </li>
+          </ol>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## TL;DR

Add a presentation-ready `@skills:` system card and deploy it through GitHub Pages.

## Hackathon presentation

- Add a self-contained system-card page at `/hackathon/`
- Explain the `@skills:` lifecycle, `atskills.one`, and reusable team knowledge
- Include two practical workflows for using an existing skill and capturing a reusable skill
- Add presenter notes and local preview instructions
- Link the presentation from the root README

## Deployment

- Add a GitHub Pages workflow that publishes the repository root on changes to `main`
- Expected URL: https://sylphai-inc.github.io/adal-cli/hackathon/

## Testing

- Rendered the page with Chrome at 1536 × 1791
- Verified both workflow rows, commands, fonts, icons, and connectors
- Validated workflow YAML and external links
- Checked the staged diff for whitespace errors and secrets

🌸 Generated with [AdaL](https://github.com/adal-cli/)
